### PR TITLE
Refactor validate word options to use lookup function

### DIFF
--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useGameStore } from '../store/useGameStore';
 import { validateWord } from '../engine/validate';
+import { hasWord } from '../dictionary/loader';
 
 export default function WordInput() {
   const [word, setWord] = useState('');
@@ -21,7 +22,7 @@ export default function WordInput() {
     length: requiredLength,
     startLetter,
     usedWords,
-    dictionary,
+    hasWord: (w) => hasWord(dictionary, w),
     noRepeats: rules.noRepeats,
     useWildcard,
   });

--- a/src/engine/validate.ts
+++ b/src/engine/validate.ts
@@ -1,4 +1,4 @@
-import { Dictionary, hasWord } from '../dictionary/loader';
+import type { Dictionary } from '../dictionary/loader';
 
 export function normalize(word: string): string {
   return word.trim().toLowerCase();
@@ -8,9 +8,10 @@ interface Options {
   length: number;
   startLetter: string;
   usedWords: Set<string>;
-  dictionary: Dictionary;
+  hasWord: (word: string) => boolean;
   noRepeats?: boolean;
   useWildcard?: boolean;
+  canSatisfy?: (letter: string, length: number) => boolean;
 }
 
 export function validateWord(
@@ -26,7 +27,7 @@ export function validateWord(
       return { accepted: false, reason: 'start' };
     }
   }
-  if (!hasWord(opts.dictionary, w)) {
+  if (!opts.hasWord(w)) {
     return { accepted: false, reason: 'dictionary' };
   }
   if (opts.noRepeats && opts.usedWords.has(w)) {

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -8,6 +8,7 @@ import {
 } from '../engine';
 import { rollDie } from '../engine/dice';
 import { validateWord, normalize } from '../engine/validate';
+import { hasWord } from '../dictionary/loader';
 import type { Dictionary } from '../dictionary/loader';
 
 export type PlayerId = 0 | 1;
@@ -64,7 +65,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       length: state.requiredLength,
       startLetter: state.startLetter,
       usedWords: state.usedWords,
-      dictionary: state.dictionary,
+      hasWord: (w) => hasWord(state.dictionary, w),
       noRepeats: state.rules.noRepeats,
       useWildcard,
     });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { validateWord } from '../src/engine/validate';
-import { loadWordlist } from '../src/dictionary/loader';
+import { loadWordlist, hasWord } from '../src/dictionary/loader';
 
 let dict: Set<string>;
 
@@ -14,7 +14,7 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'a',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: false,
     });
     expect(res.accepted).toBe(true);
@@ -25,7 +25,7 @@ describe('validateWord', () => {
       length: 4,
       startLetter: 'a',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -37,7 +37,7 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'b',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -45,7 +45,7 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'b',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: false,
       useWildcard: true,
     });
@@ -57,7 +57,7 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'z',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -70,7 +70,7 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'a',
       usedWords: used,
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
       noRepeats: true,
     });
     expect(res.accepted).toBe(false);


### PR DESCRIPTION
## Summary
- extend `validateWord` options with `hasWord` and optional `canSatisfy`
- remove direct dictionary access in word validation
- update store, UI, and tests to provide word lookup

## Testing
- `pnpm test`
- `pnpm lint` *(fails: React defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7380cb22c83249ac03a5b3e79bee9