### PR TITLE
Show last roll with Dice component in HUD

### DIFF
--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -1,9 +1,21 @@
-import React from 'react';
 import { useGameStore } from '../store/useGameStore';
 
-export default function Dice() {
+const faces = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
+
+interface DiceProps {
+  value?: number;
+}
+
+export default function Dice({ value }: DiceProps) {
+  if (typeof value === 'number') {
+    return (
+      <div className="w-12 h-12 border rounded flex items-center justify-center text-2xl">
+        {faces[value - 1]}
+      </div>
+    );
+  }
+
   const { lastDie, roll } = useGameStore();
-  const faces = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
   return (
     <button
       className="w-12 h-12 border rounded flex items-center justify-center text-2xl"

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Dice from './Dice';
 import { useGameStore } from '../store/useGameStore';
 
@@ -14,8 +13,7 @@ export default function HUD() {
   return (
     <div className="space-y-2">
       <div className="flex items-center space-x-4">
-        <Dice />
-        <div>Last Roll: {lastDie}</div>
+        <Dice value={lastDie} />
         <div>Required: {requiredLength}</div>
         <div>Start: {startLetter}</div>
         <div>Current Player: {current + 1}</div>


### PR DESCRIPTION
## Summary
- Replace text-based last roll with `<Dice value={lastDie}>` in HUD
- Extend `Dice` component to accept an optional value prop for static display

## Testing
- `pnpm lint` (fails: unused React and other pre-existing errors)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7380aba4483249f67f7ec570c6fab