### PR TITLE
refactor: decouple word validation from dictionary

### DIFF
--- a/src/engine/validate.ts
+++ b/src/engine/validate.ts
@@ -1,4 +1,4 @@
-import { Dictionary, hasWord } from '../dictionary/loader';
+import type { Dictionary } from '../dictionary/loader';
 
 export function normalize(word: string): string {
   return word.trim().toLowerCase();
@@ -8,14 +8,15 @@ interface Options {
   length: number;
   startLetter: string;
   usedWords: Set<string>;
-  dictionary: Dictionary;
+  hasWord: (word: string) => boolean;
+  canSatisfy?: (letter: string, length: number) => boolean;
   noRepeats?: boolean;
   useWildcard?: boolean;
 }
 
 export function validateWord(
   word: string,
-  opts: Options
+  opts: Options,
 ): { accepted: boolean; reason?: string } {
   const w = normalize(word);
   if (w.length !== opts.length) {
@@ -26,7 +27,7 @@ export function validateWord(
       return { accepted: false, reason: 'start' };
     }
   }
-  if (!hasWord(opts.dictionary, w)) {
+  if (!opts.hasWord(w)) {
     return { accepted: false, reason: 'dictionary' };
   }
   if (opts.noRepeats && opts.usedWords.has(w)) {
@@ -38,7 +39,7 @@ export function validateWord(
 export function canSatisfy(
   letter: string,
   length: number,
-  dict: Dictionary
+  dict: Dictionary,
 ): boolean {
   const lower = letter.toLowerCase();
   for (const word of dict) {

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { validateWord } from '../src/engine/validate';
-import { loadWordlist } from '../src/dictionary/loader';
+import { validateWord, canSatisfy } from '../src/engine/validate';
+import { loadWordlist, hasWord } from '../src/dictionary/loader';
 
 let dict: Set<string>;
 
@@ -14,7 +14,8 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'a',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: false,
     });
     expect(res.accepted).toBe(true);
@@ -25,7 +26,8 @@ describe('validateWord', () => {
       length: 4,
       startLetter: 'a',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -37,7 +39,8 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'b',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -45,7 +48,8 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'b',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: false,
       useWildcard: true,
     });
@@ -57,7 +61,8 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'z',
       usedWords: new Set(),
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: false,
     });
     expect(res.accepted).toBe(false);
@@ -70,7 +75,8 @@ describe('validateWord', () => {
       length: 5,
       startLetter: 'a',
       usedWords: used,
-      dictionary: dict,
+      hasWord: (w) => hasWord(dict, w),
+      canSatisfy: (l, len) => canSatisfy(l, len, dict),
       noRepeats: true,
     });
     expect(res.accepted).toBe(false);


### PR DESCRIPTION
## Summary
- decouple word validation from store dictionary by injecting helpers
- support validator callbacks in engine and tests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: React import unused, no-constant-condition, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68a7380dcfa08324ba7faf9cd2b71cf5