### PR TITLE
Add retry and error feedback for dictionary load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Board from './components/Board';
 import WordInput from './components/WordInput';
 import HUD from './components/HUD';
@@ -8,11 +8,39 @@ import { useGameStore } from './store/useGameStore';
 
 export default function App() {
   const setDictionary = useGameStore((s) => s.setDictionary);
-  useEffect(() => {
-    loadWordlist().then((d) => setDictionary(d));
+  const [dictError, setDictError] = useState<string | null>(null);
+
+  const loadDict = useCallback(() => {
+    return loadWordlist()
+      .then((d) => {
+        setDictionary(d);
+        setDictError(null);
+      })
+      .catch((e) =>
+        setDictError(
+          e instanceof Error
+            ? e.message
+            : 'Failed to load dictionary. Please try again.',
+        ),
+      );
   }, [setDictionary]);
+
+  useEffect(() => {
+    void loadDict();
+  }, [loadDict]);
   return (
     <div className="p-4 space-y-4 max-w-md mx-auto">
+      {dictError && (
+        <div
+          role="alert"
+          className="p-2 text-red-600 text-sm border border-red-400 rounded"
+        >
+          {dictError}{' '}
+          <button className="underline" onClick={loadDict} type="button">
+            Retry
+          </button>
+        </div>
+      )}
       <HUD />
       <Board />
       <WordInput />

--- a/tests/dictionary-loader.test.ts
+++ b/tests/dictionary-loader.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadWordlist } from '../src/dictionary/loader';
+
+describe('loadWordlist retries', () => {
+  it('retries failed fetches and eventually succeeds', async () => {
+    const fetchMock = vi
+      .fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>()
+      .mockRejectedValueOnce(new Error('net'))
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => 'one\ntwo',
+      } as Response);
+
+    const dict = await loadWordlist('/fake', {
+      fetchFn: fetchMock,
+      retries: 1,
+      delayMs: 0,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(dict.has('one')).toBe(true);
+    expect(dict.has('two')).toBe(true);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('net'));
+    await expect(
+      loadWordlist('/fake', { fetchFn: fetchMock, retries: 1, delayMs: 0 }),
+    ).rejects.toThrow(/Unable to load dictionary/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- allow configuring retries/delay and injecting a fetch function in `loadWordlist`
- add unit tests validating dictionary fetch retry behavior
- surface dictionary load failures in an accessible alert

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac33244b7883248b357b07e9000dc8