### PR TITLE
refactor: improve responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ export default function App() {
     void loadDict();
   }, [loadDict]);
   return (
-    <div className="p-4 space-y-4 max-w-md mx-auto">
+    <div className="p-4 space-y-4 max-w-4xl mx-auto">
       {dictError && (
         <div
           role="alert"
@@ -41,9 +41,11 @@ export default function App() {
           </button>
         </div>
       )}
-      <HUD />
-      <Board />
-      <WordInput />
+      <div className="flex flex-col items-center gap-4 md:flex-row md:items-start md:justify-center">
+        <HUD />
+        <Board />
+        <WordInput />
+      </div>
       <ToggleBar />
     </div>
   );

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,8 +2,6 @@ import { useGameStore } from '../store/useGameStore';
 import Cell from './Cell';
 import { indexToPosition } from '../engine/board';
 
-const CELL_SIZE = 32; // w-8 = 2rem ~32px
-
 export default function Board() {
   const { positions, rules } = useGameStore();
   const cells: JSX.Element[] = [];
@@ -20,10 +18,10 @@ export default function Board() {
   ].map((item, i) => {
     const from = indexToPosition(item.from, rules.boardSize);
     const to = indexToPosition(item.to, rules.boardSize);
-    const x1 = from.col * CELL_SIZE + CELL_SIZE / 2;
-    const y1 = (9 - from.row) * CELL_SIZE + CELL_SIZE / 2;
-    const x2 = to.col * CELL_SIZE + CELL_SIZE / 2;
-    const y2 = (9 - to.row) * CELL_SIZE + CELL_SIZE / 2;
+    const x1 = from.col + 0.5;
+    const y1 = 9 - from.row + 0.5;
+    const x2 = to.col + 0.5;
+    const y2 = 9 - to.row + 0.5;
     return (
       <line
         key={i}
@@ -32,16 +30,19 @@ export default function Board() {
         x2={x2}
         y2={y2}
         stroke={item.color}
-        strokeWidth={4}
+        strokeWidth={0.2}
         strokeLinecap="round"
       />
     );
   });
 
   return (
-    <div className="relative w-80 h-80">
+    <div className="relative w-full aspect-square max-w-sm">
       <div className="grid grid-cols-10 w-full h-full">{cells}</div>
-      <svg className="absolute inset-0 w-full h-full pointer-events-none">
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        viewBox="0 0 10 10"
+      >
         {lines}
       </svg>
     </div>


### PR DESCRIPTION
## Summary
- make game board responsive using full width with aspect-square and scalable SVG lines
- restructure app layout to stack on small screens and align horizontally on wider screens

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac36cebf448324bad3c0f9482cc177