### PR TITLE
feat: add dictionary selection

### DIFF
--- a/public/dictionary/animals.txt
+++ b/public/dictionary/animals.txt
@@ -1,0 +1,10 @@
+ant
+bear
+cat
+dog
+eel
+fox
+goat
+horse
+iguana
+jaguar

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -1,15 +1,40 @@
+import { useState } from 'react';
+import { loadWordlist } from '../dictionary/loader';
 import { useGameStore } from '../store/useGameStore';
 
 export default function ToggleBar() {
   const rules = useGameStore((s) => s.rules);
-  const setRules = useGameStore((s) => s.newGame);
+  const newGame = useGameStore((s) => s.newGame);
+  const setDictionary = useGameStore((s) => s.setDictionary);
+  const [dictId, setDictId] = useState('english');
+
+  const changeDict = (id: string) => {
+    void loadWordlist(id).then((d) => {
+      setDictionary(d);
+      newGame();
+    });
+  };
+
+  const handleDictChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    setDictId(id);
+    changeDict(id);
+  };
   return (
     <div className="flex space-x-2">
+      <select
+        className="border p-1 rounded"
+        value={dictId}
+        onChange={handleDictChange}
+      >
+        <option value="english">English</option>
+        <option value="animals">Animals</option>
+      </select>
       <label>
         <input
           type="checkbox"
           checked={rules.challengeMode}
-          onChange={() => setRules({ challengeMode: !rules.challengeMode })}
+          onChange={() => newGame({ challengeMode: !rules.challengeMode })}
         />
         Challenge
       </label>
@@ -17,7 +42,7 @@ export default function ToggleBar() {
         <input
           type="checkbox"
           checked={rules.noRepeats}
-          onChange={() => setRules({ noRepeats: !rules.noRepeats })}
+          onChange={() => newGame({ noRepeats: !rules.noRepeats })}
         />
         No Repeats
       </label>
@@ -25,7 +50,7 @@ export default function ToggleBar() {
         <input
           type="checkbox"
           checked={rules.timer}
-          onChange={() => setRules({ timer: !rules.timer })}
+          onChange={() => newGame({ timer: !rules.timer })}
         />
         Timer
       </label>

--- a/src/dictionary/loader.ts
+++ b/src/dictionary/loader.ts
@@ -11,9 +11,11 @@ function normalize(text: string): Dictionary {
 }
 
 /**
- * Loads the word list from:
- * - Browser: fetch('/dictionary/english.txt') served from /public
- * - Node/Vitest: reads {projectRoot}/public/dictionary/english.txt
+ * Loads the word list given an identifier or path:
+ * - identifier: "english" -> '/dictionary/english.txt'
+ * - full path: '/dictionary/animals.txt'
+ * - Browser: fetch('/dictionary/...') served from /public
+ * - Node/Vitest: reads {projectRoot}/public/dictionary/...txt
  */
 export interface LoadOptions {
   retries?: number;
@@ -22,13 +24,18 @@ export interface LoadOptions {
 }
 
 export async function loadWordlist(
-  path = '/dictionary/english.txt',
+  identifier = 'english',
   opts: LoadOptions = {},
 ): Promise<Dictionary> {
   const isNode = typeof process !== 'undefined' && !!process.versions?.node;
   const retries = opts.retries ?? 2;
   const delayMs = opts.delayMs ?? 500;
   const fetchFn = opts.fetchFn;
+
+  const path =
+    identifier.startsWith('/') || identifier.endsWith('.txt')
+      ? identifier
+      : `/dictionary/${identifier}.txt`;
 
   if (isNode && !fetchFn) {
     const { readFile } = await import('fs/promises');

--- a/tests/dictionary.test.ts
+++ b/tests/dictionary.test.ts
@@ -1,0 +1,14 @@
+import { loadWordlist, hasWord } from '../src/dictionary/loader';
+
+describe('loadWordlist', () => {
+  it('loads default english dictionary', async () => {
+    const dict = await loadWordlist();
+    expect(hasWord(dict, 'abacus')).toBe(true);
+  });
+
+  it('loads dictionary by identifier', async () => {
+    const dict = await loadWordlist('animals');
+    expect(hasWord(dict, 'cat')).toBe(true);
+    expect(hasWord(dict, 'abacus')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- allow dictionary loader to accept an identifier and map to file paths
- add themed "animals" word list with tests
- expose dictionary selection in ToggleBar UI

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac36e78e3c83248d9f8bc94b5480fc