### PR TITLE
feat: add hint suggestions for words

### DIFF
--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -29,6 +29,14 @@ export default function ToggleBar() {
         />
         Timer
       </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={rules.hints}
+          onChange={() => setRules({ hints: !rules.hints })}
+        />
+        Hints
+      </label>
     </div>
   );
 }

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useGameStore } from '../store/useGameStore';
 import { validateWord } from '../engine/validate';
-import { hasWord } from '../dictionary/loader';
+import { hasWord, suggestWords } from '../dictionary/loader';
 
 export default function WordInput() {
   const [word, setWord] = useState('');
@@ -45,6 +45,13 @@ export default function WordInput() {
 
   const canUseWildcard = wildcards[current] > 0;
 
+  const hints =
+    rules.hints && requiredLength > 0
+      ? suggestWords(dictionary, startLetter, requiredLength, 5).filter((w) =>
+          w.startsWith(word.toLowerCase()),
+        )
+      : [];
+
   return (
     <div className="space-y-2">
       <div className="flex space-x-2 items-center">
@@ -74,6 +81,13 @@ export default function WordInput() {
         <div className="text-sm text-red-500">
           {messages[validation.reason ?? ''] || ''}
         </div>
+      )}
+      {hints.length > 0 && (
+        <ul className="text-sm text-gray-500 flex space-x-2">
+          {hints.map((h) => (
+            <li key={h}>{h}</li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/dictionary/loader.ts
+++ b/src/dictionary/loader.ts
@@ -67,3 +67,25 @@ export async function loadWordlist(
 export function hasWord(dict: Dictionary, word: string): boolean {
   return dict.has(word.toLowerCase());
 }
+
+/**
+ * Returns up to `limit` words that start with `letter` and have the given
+ * `length`. Suggestions are pulled directly from the dictionary in insertion
+ * order and are intended for lightweight hints.
+ */
+export function suggestWords(
+  dict: Dictionary,
+  letter: string,
+  length: number,
+  limit = 5,
+): string[] {
+  const lower = letter.toLowerCase();
+  const suggestions: string[] = [];
+  for (const word of dict) {
+    if (word.length === length && word.startsWith(lower)) {
+      suggestions.push(word);
+      if (suggestions.length >= limit) break;
+    }
+  }
+  return suggestions;
+}

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -20,4 +20,5 @@ export const defaultRules: Rules = {
   challengeMode: false,
   noRepeats: false,
   timer: false,
+  hints: false,
 };

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -13,4 +13,5 @@ export interface Rules {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
+  hints: boolean;
 }

--- a/tests/dictionary-loader.test.ts
+++ b/tests/dictionary-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { loadWordlist } from '../src/dictionary/loader';
+import { loadWordlist, suggestWords } from '../src/dictionary/loader';
 
 describe('loadWordlist retries', () => {
   it('retries failed fetches and eventually succeeds', async () => {
@@ -27,5 +27,13 @@ describe('loadWordlist retries', () => {
       loadWordlist('/fake', { fetchFn: fetchMock, retries: 1, delayMs: 0 }),
     ).rejects.toThrow(/Unable to load dictionary/);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('suggestWords', () => {
+  it('returns limited suggestions by start letter and length', () => {
+    const dict = new Set(['apple', 'apply', 'apart', 'angle', 'boat']);
+    const res = suggestWords(dict, 'a', 5, 2);
+    expect(res).toEqual(['apple', 'apply']);
   });
 });

--- a/tests/snakes-ladders.test.ts
+++ b/tests/snakes-ladders.test.ts
@@ -9,6 +9,8 @@ const chainRules: Rules = {
   allowWildcards: true,
   challengeMode: false,
   noRepeats: false,
+  timer: false,
+  hints: false,
 };
 
 const ladderRules: Rules = {
@@ -18,6 +20,8 @@ const ladderRules: Rules = {
   allowWildcards: true,
   challengeMode: false,
   noRepeats: false,
+  timer: false,
+  hints: false,
 };
 
 describe('resolveSnakesAndLadders', () => {


### PR DESCRIPTION
## Summary
- add `suggestWords` dictionary helper for lightweight word hints
- expose Hints toggle in settings and default rules
- surface word suggestions under input when Hints are enabled

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac36f809f483248d195b51baf5e8fe