### PR TITLE
refactor: add explicit prop interfaces and typings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import ToggleBar from './components/ToggleBar';
 import { loadWordlist } from './dictionary/loader';
 import { useGameStore } from './store/useGameStore';
 
-export default function App() {
+export default function App(): JSX.Element {
   const setDictionary = useGameStore((s) => s.setDictionary);
   const [dictError, setDictError] = useState<string | null>(null);
 

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -4,7 +4,7 @@ import { indexToPosition } from '../engine/board';
 
 const CELL_SIZE = 32; // w-8 = 2rem ~32px
 
-export default function Board() {
+export default function Board(): JSX.Element {
   const { positions, rules } = useGameStore();
   const cells: JSX.Element[] = [];
   for (let row = 9; row >= 0; row--) {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,26 +1,25 @@
-
 import { PlayerId } from '../store/useGameStore';
 
-interface CellProps {
+export interface CellProps {
   index: number;
   positions: Record<PlayerId, number>;
 }
 
-export default function Cell({ index, positions }: CellProps) {
+export default function Cell({ index, positions }: CellProps): JSX.Element {
   const tokens: JSX.Element[] = [];
   if (positions[0] === index)
     tokens.push(
       <span
         key="p1"
         className="absolute top-1 left-1 w-3 h-3 rounded-full bg-red-500"
-      />
+      />,
     );
   if (positions[1] === index)
     tokens.push(
       <span
         key="p2"
         className="absolute bottom-1 right-1 w-3 h-3 rounded-full bg-blue-500"
-      />
+      />,
     );
   return (
     <div className="relative w-8 h-8 border flex items-center justify-center text-xs">

--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -2,11 +2,11 @@ import { useGameStore } from '../store/useGameStore';
 
 const faces = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
 
-interface DiceProps {
+export interface DiceProps {
   value?: number;
 }
 
-export default function Dice({ value }: DiceProps) {
+export default function Dice({ value }: DiceProps): JSX.Element {
   if (typeof value === 'number') {
     return (
       <div className="w-12 h-12 border rounded flex items-center justify-center text-2xl">

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,7 +1,9 @@
 import Dice from './Dice';
 import { useGameStore } from '../store/useGameStore';
 
-export default function HUD() {
+export interface HUDProps {}
+
+export default function HUD(): JSX.Element {
   const { requiredLength, startLetter, wildcards, current, positions } =
     useGameStore();
   return (

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -1,6 +1,8 @@
 import { useGameStore } from '../store/useGameStore';
 
-export default function ToggleBar() {
+export interface ToggleBarProps {}
+
+export default function ToggleBar(): JSX.Element {
   const rules = useGameStore((s) => s.rules);
   const setRules = useGameStore((s) => s.newGame);
   return (

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -3,7 +3,7 @@ import { useGameStore } from '../store/useGameStore';
 import { validateWord } from '../engine/validate';
 import { hasWord } from '../dictionary/loader';
 
-export default function WordInput() {
+export default function WordInput(): JSX.Element {
   const [word, setWord] = useState('');
   const [useWildcard, setUseWildcard] = useState(false);
   const submitWord = useGameStore((s) => s.submitWord);

--- a/src/engine/dice.ts
+++ b/src/engine/dice.ts
@@ -1,9 +1,9 @@
 export class RNG {
   private seed: number;
-  constructor(seed = Date.now()) {
+  constructor(seed: number = Date.now()) {
     this.seed = seed;
   }
-  next() {
+  next(): number {
     this.seed = (this.seed * 9301 + 49297) % 233280;
     return this.seed / 233280;
   }

--- a/src/pwa/registerSW.ts
+++ b/src/pwa/registerSW.ts
@@ -1,4 +1,4 @@
-export function registerSW() {
+export function registerSW(): void {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/service-worker.js').catch(() => {});


### PR DESCRIPTION
## Summary
- define prop interfaces for Dice, HUD, and ToggleBar components
- add explicit return types and parameter typings for exported functions and hooks

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68ac3708fb2c8324948ca40312b98875