### PR TITLE
Add single-player mode with basic AI

### DIFF
--- a/src/engine/ai.ts
+++ b/src/engine/ai.ts
@@ -1,0 +1,25 @@
+interface AiParams {
+  dictionary: Set<string>;
+  length: number;
+  startLetter: string;
+  usedWords: Set<string>;
+  noRepeats: boolean;
+}
+
+export function chooseRandomWord({
+  dictionary,
+  length,
+  startLetter,
+  usedWords,
+  noRepeats,
+}: AiParams): string | null {
+  let candidates = Array.from(dictionary).filter(
+    (w) => w.length === length && w.startsWith(startLetter)
+  );
+  if (noRepeats) {
+    candidates = candidates.filter((w) => !usedWords.has(w));
+  }
+  if (candidates.length === 0) return null;
+  const index = Math.floor(Math.random() * candidates.length);
+  return candidates[index];
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -3,3 +3,4 @@ export * from './board';
 export * from './rules';
 export * from './dice';
 export * from './validate';
+export * from './ai';

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -20,4 +20,5 @@ export const defaultRules: Rules = {
   challengeMode: false,
   noRepeats: false,
   timer: false,
+  mode: 'multi',
 };

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -13,4 +13,5 @@ export interface Rules {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
+  mode: 'single' | 'multi';
 }

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -8,6 +8,7 @@ import {
 } from '../engine';
 import { rollDie } from '../engine/dice';
 import { validateWord, normalize } from '../engine/validate';
+import { chooseRandomWord } from '../engine/ai';
 import { hasWord } from '../dictionary/loader';
 import type { Dictionary } from '../dictionary/loader';
 
@@ -103,5 +104,21 @@ export const useGameStore = create<GameState>((set, get) => ({
       current: s.current === 0 ? 1 : 0,
       requiredLength: 0,
     }));
+    const state = get();
+    if (state.rules.mode === 'single' && state.current === 1) {
+      get().roll();
+      const aiState = get();
+      const word = chooseRandomWord({
+        dictionary: aiState.dictionary,
+        length: aiState.requiredLength,
+        startLetter: aiState.startLetter,
+        usedWords: aiState.usedWords,
+        noRepeats: aiState.rules.noRepeats,
+      });
+      if (word) {
+        get().submitWord(word);
+      }
+      set({ current: 0, requiredLength: 0 });
+    }
   },
 }));

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { useGameStore } from '../src/store/useGameStore';
 import { loadWordlist } from '../src/dictionary/loader';
+import * as diceModule from '../src/engine/dice';
+import * as aiModule from '../src/engine/ai';
 
 let dict: Set<string>;
 
@@ -60,5 +62,21 @@ describe('game store', () => {
   it('endTurn switches player', () => {
     useGameStore.getState().endTurn();
     expect(useGameStore.getState().current).toBe(1);
+  });
+
+  it('AI plays automatically in single mode', () => {
+    useGameStore.getState().newGame({ mode: 'single' });
+    useGameStore.setState({ dictionary: dict, startLetter: 'a' });
+    const rollSpy = vi.spyOn(diceModule, 'rollDie').mockReturnValue(5);
+    const aiSpy = vi
+      .spyOn(aiModule, 'chooseRandomWord')
+      .mockReturnValue('apple');
+    useGameStore.getState().endTurn();
+    expect(aiSpy).toHaveBeenCalled();
+    expect(useGameStore.getState().positions[1]).toBe(5);
+    expect(useGameStore.getState().startLetter).toBe('e');
+    expect(useGameStore.getState().current).toBe(0);
+    rollSpy.mockRestore();
+    aiSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Extend game rules with `mode` field and default to `multi`
- Implement basic AI to pick random valid words
- Trigger AI turn automatically in single-player mode and test it

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac36ec0c7c83248830af90987c195f