### PR TITLE
Improve accessibility for input and toggle controls

### DIFF
--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -4,31 +4,35 @@ export default function ToggleBar() {
   const rules = useGameStore((s) => s.rules);
   const setRules = useGameStore((s) => s.newGame);
   return (
-    <div className="flex space-x-2">
-      <label>
+    <fieldset className="flex space-x-2">
+      <legend className="sr-only">Game options</legend>
+      <div className="flex items-center space-x-1">
         <input
+          id="toggle-challenge"
           type="checkbox"
           checked={rules.challengeMode}
           onChange={() => setRules({ challengeMode: !rules.challengeMode })}
         />
-        Challenge
-      </label>
-      <label>
+        <label htmlFor="toggle-challenge">Challenge</label>
+      </div>
+      <div className="flex items-center space-x-1">
         <input
+          id="toggle-no-repeats"
           type="checkbox"
           checked={rules.noRepeats}
           onChange={() => setRules({ noRepeats: !rules.noRepeats })}
         />
-        No Repeats
-      </label>
-      <label>
+        <label htmlFor="toggle-no-repeats">No Repeats</label>
+      </div>
+      <div className="flex items-center space-x-1">
         <input
+          id="toggle-timer"
           type="checkbox"
           checked={rules.timer}
           onChange={() => setRules({ timer: !rules.timer })}
         />
-        Timer
-      </label>
-    </div>
+        <label htmlFor="toggle-timer">Timer</label>
+      </div>
+    </fieldset>
   );
 }

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -48,13 +48,19 @@ export default function WordInput() {
   return (
     <div className="space-y-2">
       <div className="flex space-x-2 items-center">
+        <label htmlFor="word-input" className="sr-only">
+          Enter word
+        </label>
         <input
+          id="word-input"
+          type="text"
           className="border p-1"
           value={word}
           onChange={(e) => setWord(e.target.value)}
         />
-        <label className="flex items-center space-x-1">
+        <label htmlFor="use-wildcard" className="flex items-center space-x-1">
           <input
+            id="use-wildcard"
             type="checkbox"
             checked={useWildcard}
             disabled={!canUseWildcard}
@@ -66,6 +72,7 @@ export default function WordInput() {
           className="border px-2"
           onClick={handleSubmit}
           disabled={!validation.accepted}
+          aria-label="Submit word"
         >
           Submit
         </button>


### PR DESCRIPTION
## Summary
- Add hidden label and aria-labels to word submission controls for better screen reader support
- Group rule toggles inside a fieldset with legend and explicit labels

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac36fa53f483248d42a3e7bdaaff66