### PR TITLE
feat: add themed UI and card layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ export default function App() {
     void loadDict();
   }, [loadDict]);
   return (
-    <div className="p-4 space-y-4 max-w-md mx-auto">
+    <div className="p-4 space-y-4 max-w-md mx-auto font-sans bg-background text-primary">
       {dictError && (
         <div
           role="alert"
@@ -41,9 +41,15 @@ export default function App() {
           </button>
         </div>
       )}
-      <HUD />
-      <Board />
-      <WordInput />
+      <div className="bg-surface p-4 rounded shadow">
+        <HUD />
+      </div>
+      <div className="bg-surface p-4 rounded shadow">
+        <Board />
+      </div>
+      <div className="bg-surface p-4 rounded shadow">
+        <WordInput />
+      </div>
       <ToggleBar />
     </div>
   );

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -5,7 +5,7 @@ export default function HUD() {
   const { requiredLength, startLetter, wildcards, current, positions } =
     useGameStore();
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 text-primary font-sans">
       <div className="flex items-center space-x-4">
         <Dice />
         <div>Required: {requiredLength || '-'}</div>

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -4,30 +4,33 @@ export default function ToggleBar() {
   const rules = useGameStore((s) => s.rules);
   const setRules = useGameStore((s) => s.newGame);
   return (
-    <div className="flex space-x-2">
-      <label>
+    <div className="flex space-x-2 text-primary font-sans">
+      <label className="flex items-center space-x-1">
         <input
           type="checkbox"
+          className="accent-secondary"
           checked={rules.challengeMode}
           onChange={() => setRules({ challengeMode: !rules.challengeMode })}
         />
-        Challenge
+        <span>Challenge</span>
       </label>
-      <label>
+      <label className="flex items-center space-x-1">
         <input
           type="checkbox"
+          className="accent-secondary"
           checked={rules.noRepeats}
           onChange={() => setRules({ noRepeats: !rules.noRepeats })}
         />
-        No Repeats
+        <span>No Repeats</span>
       </label>
-      <label>
+      <label className="flex items-center space-x-1">
         <input
           type="checkbox"
+          className="accent-secondary"
           checked={rules.timer}
           onChange={() => setRules({ timer: !rules.timer })}
         />
-        Timer
+        <span>Timer</span>
       </label>
     </div>
   );

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -46,16 +46,17 @@ export default function WordInput() {
   const canUseWildcard = wildcards[current] > 0;
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 text-primary font-sans">
       <div className="flex space-x-2 items-center">
         <input
-          className="border p-1"
+          className="border border-primary p-1 rounded"
           value={word}
           onChange={(e) => setWord(e.target.value)}
         />
         <label className="flex items-center space-x-1">
           <input
             type="checkbox"
+            className="accent-secondary"
             checked={useWildcard}
             disabled={!canUseWildcard}
             onChange={() => setUseWildcard(!useWildcard)}
@@ -63,7 +64,7 @@ export default function WordInput() {
           <span>Wildcard</span>
         </label>
         <button
-          className="border px-2"
+          className="px-2 py-1 rounded bg-primary text-white disabled:opacity-50"
           onClick={handleSubmit}
           disabled={!validation.accepted}
         >

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,18 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1E3A8A',
+        secondary: '#F59E0B',
+        background: '#F3F4F6',
+        surface: '#FFFFFF',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
+  },
   plugins: [],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- extend Tailwind with custom colour palette and Inter font
- apply theme styles to HUD, word input, and toggle bar
- wrap HUD, board, and input components in card-style containers for separation

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac36c3201c83249987ece3e31ebc62