### PR TITLE
Refactor setup screen and HUD layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import Board from './components/Board';
 import WordInput from './components/WordInput';
 import HUD from './components/HUD';
-import ToggleBar from './components/ToggleBar';
 import { loadWordlist } from './dictionary/loader';
 import { useGameStore } from './store/useGameStore';
 import GameSetupModal from './components/GameSetupModal';
@@ -64,10 +63,11 @@ export default function App() {
             />
           ) : (
             <>
-              <HUD />
-              <Board />
+              <div className="flex gap-4 items-start justify-center">
+                <Board />
+                <HUD />
+              </div>
               <WordInput />
-              <ToggleBar />
             </>
           )}
         </>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -11,26 +11,30 @@ export default function Cell({ index, positions, letter }: CellProps) {
   const tokens: JSX.Element[] = [];
   if (positions[0] === index)
     tokens.push(
-      <motion.span
+      <motion.img
         layoutId="p1"
         key="p1"
-        className="absolute top-1 right-1 w-3 h-3 rounded-full bg-red-500"
+        src="/assets/redpawn.svg"
+        alt="P1"
+        className="absolute top-1 right-1 w-4 h-4"
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />,
     );
   if (positions[1] === index)
     tokens.push(
-      <motion.span
+      <motion.img
         layoutId="p2"
         key="p2"
-        className="absolute bottom-1 right-1 w-3 h-3 rounded-full bg-blue-500"
+        src="/assets/bluepawn.svg"
+        alt="P2"
+        className="absolute top-1 right-1 w-4 h-4"
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />,
     );
   return (
     <div className="relative w-full aspect-square border flex items-center justify-center">
       <span className="absolute top-1 left-1 text-[0.5rem]">{index + 1}</span>
-      <span className="text-lg">{letter}</span>
+      <span className="text-[clamp(0.5rem,2vmin,1.25rem)]">{letter}</span>
       {tokens}
     </div>
   );

--- a/src/components/GameSetupModal.tsx
+++ b/src/components/GameSetupModal.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 type SetupOptions = {
   boardSize: number;
   challengeMode: boolean;
+  noRepeats: boolean;
+  timer: boolean;
   mode: 'single' | 'multi';
 };
 
@@ -11,24 +13,27 @@ interface Props {
 }
 
 export default function GameSetupModal({ onStart }: Props) {
-  const [boardSize, setBoardSize] = useState(100);
+  const [boardWidth, setBoardWidth] = useState(10);
   const [challengeMode, setChallengeMode] = useState(false);
+  const [noRepeats, setNoRepeats] = useState(false);
+  const [timer, setTimer] = useState(false);
   const [mode, setMode] = useState<'single' | 'multi'>('multi');
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
-      <div className="bg-white p-4 rounded shadow w-80 space-y-4">
+    <div className="fixed inset-0 flex items-start justify-start bg-black/50">
+      <div className="bg-white p-4 m-4 rounded shadow w-64 space-y-4">
         <h2 className="text-lg font-bold">Game Setup</h2>
         <label className="block text-sm">
           Board Size
-          <input
-            type="number"
-            value={boardSize}
-            min={10}
-            step={10}
-            onChange={(e) => setBoardSize(Number(e.target.value))}
+          <select
+            value={boardWidth}
+            onChange={(e) => setBoardWidth(Number(e.target.value))}
             className="mt-1 w-full border p-1"
-          />
+          >
+            <option value={8}>8×8</option>
+            <option value={10}>10×10</option>
+            <option value={12}>12×12</option>
+          </select>
         </label>
         <label className="flex items-center gap-2 text-sm">
           <input
@@ -37,6 +42,22 @@ export default function GameSetupModal({ onStart }: Props) {
             onChange={(e) => setChallengeMode(e.target.checked)}
           />
           Challenge Mode
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={noRepeats}
+            onChange={(e) => setNoRepeats(e.target.checked)}
+          />
+          No Repeats
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={timer}
+            onChange={(e) => setTimer(e.target.checked)}
+          />
+          Timer
         </label>
         <div className="text-sm space-y-1">
           <div>Mode</div>
@@ -60,7 +81,15 @@ export default function GameSetupModal({ onStart }: Props) {
         <button
           type="button"
           className="w-full bg-blue-500 text-white py-1 rounded"
-          onClick={() => onStart({ boardSize, challengeMode, mode })}
+          onClick={() =>
+            onStart({
+              boardSize: boardWidth * boardWidth,
+              challengeMode,
+              noRepeats,
+              timer,
+              mode,
+            })
+          }
         >
           Start Game
         </button>

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -5,21 +5,15 @@ export default function HUD() {
   const { requiredLength, startLetter, wildcards, current, positions } =
     useGameStore();
   return (
-    <div className="p-4 bg-white rounded shadow space-y-2">
-      <div className="flex items-center space-x-4 text-primary">
-        <Dice />
-        <div>Required: {requiredLength || '-'}</div>
-        <div>Start: {startLetter}</div>
-        <div>Current: P{current + 1}</div>
-        <div>Wildcards: {wildcards[current]}</div>
-      </div>
-      <div className="flex space-x-4">
-        <div className={current === 0 ? 'font-bold' : ''}>
-          P1: {positions[0]}
-        </div>
-        <div className={current === 1 ? 'font-bold' : ''}>
-          P2: {positions[1]}
-        </div>
+    <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
+      <Dice />
+      <div>Required: {requiredLength || '-'}</div>
+      <div>Start: {startLetter}</div>
+      <div>Current: P{current + 1}</div>
+      <div>Wildcards: {wildcards[current]}</div>
+      <div className="pt-2">
+        <div className={current === 0 ? 'font-bold' : ''}>P1: {positions[0]}</div>
+        <div className={current === 1 ? 'font-bold' : ''}>P2: {positions[1]}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Move board size and mode toggles to startup screen with fixed 8x8/10x10/12x12 options
- Show HUD as a vertical column to the right of the board and drop in-game board size selector
- Render player pawns with red/blue SVGs and adaptive letter sizing

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68acaf4521388324ad883ad1978fe114