### PR TITLE
fix: resolve merge conflicts in setup and layout components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Board from './components/Board';
 import WordInput from './components/WordInput';
 import HUD from './components/HUD';
+import ModeSummary from './components/ModeSummary';
 import { loadWordlist } from './dictionary/loader';
 import { useGameStore } from './store/useGameStore';
 import GameSetupModal from './components/GameSetupModal';
@@ -64,6 +65,7 @@ export default function App() {
           ) : (
             <>
               <div className="flex gap-4 items-start justify-center">
+                <ModeSummary />
                 <Board />
                 <HUD />
               </div>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -27,7 +27,7 @@ export default function Cell({ index, positions, letter }: CellProps) {
         key="p2"
         src="/assets/bluepawn.svg"
         alt="P2"
-        className="absolute top-1 right-1 w-4 h-4"
+        className="absolute bottom-1 left-1 w-4 h-4"
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />,
     );

--- a/src/components/GameSetupModal.tsx
+++ b/src/components/GameSetupModal.tsx
@@ -20,7 +20,7 @@ export default function GameSetupModal({ onStart }: Props) {
   const [mode, setMode] = useState<'single' | 'multi'>('multi');
 
   return (
-    <div className="fixed inset-0 flex items-start justify-start bg-black/50">
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
       <div className="bg-white p-4 m-4 rounded shadow w-64 space-y-4">
         <h2 className="text-lg font-bold">Game Setup</h2>
         <label className="block text-sm">
@@ -60,7 +60,7 @@ export default function GameSetupModal({ onStart }: Props) {
           Timer
         </label>
         <div className="text-sm space-y-1">
-          <div>Mode</div>
+          <div>Players</div>
           <label className="flex items-center gap-2">
             <input
               type="radio"

--- a/src/components/ModeSummary.tsx
+++ b/src/components/ModeSummary.tsx
@@ -1,0 +1,14 @@
+import { useGameStore } from '../store/useGameStore';
+
+export default function ModeSummary() {
+  const rules = useGameStore((s) => s.rules);
+  return (
+    <div className="p-4 bg-white rounded shadow text-sm space-y-1">
+      <h2 className="font-bold text-base">Modes</h2>
+      <div>{rules.challengeMode ? 'Challenge' : 'Easy'}</div>
+      <div>{rules.noRepeats ? 'No Repeats' : 'Repeats Allowed'}</div>
+      {rules.timer && <div>Timer Enabled</div>}
+      {rules.mode === 'single' && <div>Single Player</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- restore board layout with left-aligned mode summary and right-side HUD
- center setup modal and rename mode selector to players
- separate player tokens for clearer cell rendering

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acb946862c832488c19e7a341aae35