### PR TITLE
feat: add bot play mode

### DIFF
--- a/src/components/GameSetupModal.tsx
+++ b/src/components/GameSetupModal.tsx
@@ -5,7 +5,7 @@ type SetupOptions = {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
-  mode: 'single' | 'multi';
+  mode: 'bot' | 'multi';
 };
 
 interface Props {
@@ -17,7 +17,7 @@ export default function GameSetupModal({ onStart }: Props) {
   const [challengeMode, setChallengeMode] = useState(false);
   const [noRepeats, setNoRepeats] = useState(false);
   const [timer, setTimer] = useState(false);
-  const [mode, setMode] = useState<'single' | 'multi'>('multi');
+  const [mode, setMode] = useState<'bot' | 'multi'>('multi');
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/50">
@@ -72,10 +72,10 @@ export default function GameSetupModal({ onStart }: Props) {
           <label className="flex items-center gap-2">
             <input
               type="radio"
-              checked={mode === 'single'}
-              onChange={() => setMode('single')}
+              checked={mode === 'bot'}
+              onChange={() => setMode('bot')}
             />
-            Single Player
+            Play vs Bot
           </label>
         </div>
         <button

--- a/src/components/ModeSummary.tsx
+++ b/src/components/ModeSummary.tsx
@@ -8,7 +8,7 @@ export default function ModeSummary() {
       <div>{rules.challengeMode ? 'Challenge' : 'Easy'}</div>
       <div>{rules.noRepeats ? 'No Repeats' : 'Repeats Allowed'}</div>
       {rules.timer && <div>Timer Enabled</div>}
-      {rules.mode === 'single' && <div>Single Player</div>}
+      {rules.mode === 'bot' && <div>Vs Bot</div>}
     </div>
   );
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -13,5 +13,5 @@ export interface Rules {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
-  mode: 'single' | 'multi';
+  mode: 'bot' | 'multi';
 }

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -129,7 +129,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       requiredLength: 0,
     }));
     const state = get();
-    if (state.rules.mode === 'single' && state.current === 1) {
+    if (state.rules.mode === 'bot' && state.current === 1) {
       get().roll();
       const aiState = get();
       const word = chooseRandomWord({

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -65,7 +65,7 @@ describe('game store', () => {
   });
 
   it('AI plays automatically in single mode', () => {
-    useGameStore.getState().newGame({ mode: 'single' });
+    useGameStore.getState().newGame({ mode: 'bot' });
     useGameStore.setState({ dictionary: dict, startLetter: 'a' });
     const rollSpy = vi.spyOn(diceModule, 'rollDie').mockReturnValue(5);
     const aiSpy = vi


### PR DESCRIPTION
## Summary
- allow players to face a bot opponent
- expose bot mode option in game setup and mode summary

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acbd54332483249efff381bde523eb