### PR TITLE
Add Zen Mode for solo play

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -19,6 +19,7 @@ export default function Board() {
           index={index}
           positions={positions}
           letter={boardLetters[index]}
+          mode={rules.mode}
         />,
       );
     }

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,13 +1,15 @@
 import { PlayerId } from '../store/useGameStore';
 import { motion } from 'framer-motion';
+import type { Rules } from '../engine';
 
 interface CellProps {
   index: number;
   positions: Record<PlayerId, number>;
   letter?: string;
+  mode: Rules['mode'];
 }
 
-export default function Cell({ index, positions, letter }: CellProps) {
+export default function Cell({ index, positions, letter, mode }: CellProps) {
   const tokens: JSX.Element[] = [];
 
   if (positions[0] === index) {
@@ -19,11 +21,11 @@ export default function Cell({ index, positions, letter }: CellProps) {
         alt="P1"
         className="absolute top-1 right-1 w-4 h-4"
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-      />
+      />,
     );
   }
 
-  if (positions[1] === index) {
+  if (mode !== 'zen' && positions[1] === index) {
     tokens.push(
       <motion.img
         layoutId="p2"
@@ -32,7 +34,7 @@ export default function Cell({ index, positions, letter }: CellProps) {
         alt="P2"
         className="absolute bottom-1 right-1 w-4 h-4"
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-      />
+      />,
     );
   }
 

--- a/src/components/GameSetupModal.tsx
+++ b/src/components/GameSetupModal.tsx
@@ -5,7 +5,7 @@ type SetupOptions = {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
-  mode: 'bot' | 'multi';
+  mode: 'bot' | 'multi' | 'zen';
 };
 
 interface Props {
@@ -17,7 +17,7 @@ export default function GameSetupModal({ onStart }: Props) {
   const [challengeMode, setChallengeMode] = useState(false);
   const [noRepeats, setNoRepeats] = useState(false);
   const [timer, setTimer] = useState(false);
-  const [mode, setMode] = useState<'bot' | 'multi'>('multi');
+  const [mode, setMode] = useState<'bot' | 'multi' | 'zen'>('multi');
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/50">
@@ -61,6 +61,14 @@ export default function GameSetupModal({ onStart }: Props) {
         </label>
         <div className="text-sm space-y-1">
           <div>Players</div>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              checked={mode === 'zen'}
+              onChange={() => setMode('zen')}
+            />
+            Zen Mode
+          </label>
           <label className="flex items-center gap-2">
             <input
               type="radio"

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -2,18 +2,24 @@ import Dice from './Dice';
 import { useGameStore } from '../store/useGameStore';
 
 export default function HUD() {
-  const { requiredLength, startLetter, wildcards, current, positions } =
+  const { requiredLength, startLetter, wildcards, current, positions, rules } =
     useGameStore();
   return (
     <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
       <Dice />
       <div>Required: {requiredLength || '-'}</div>
       <div>Start: {startLetter}</div>
-      <div>Current: P{current + 1}</div>
+      <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>
       <div>Wildcards: {wildcards[current]}</div>
       <div className="pt-2">
-        <div className={current === 0 ? 'font-bold' : ''}>P1: {positions[0]}</div>
-        <div className={current === 1 ? 'font-bold' : ''}>P2: {positions[1]}</div>
+        <div className={current === 0 ? 'font-bold' : ''}>
+          P1: {positions[0]}
+        </div>
+        {rules.mode !== 'zen' && (
+          <div className={current === 1 ? 'font-bold' : ''}>
+            P2: {positions[1]}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ModeSummary.tsx
+++ b/src/components/ModeSummary.tsx
@@ -9,6 +9,7 @@ export default function ModeSummary() {
       <div>{rules.noRepeats ? 'No Repeats' : 'Repeats Allowed'}</div>
       {rules.timer && <div>Timer Enabled</div>}
       {rules.mode === 'bot' && <div>Vs Bot</div>}
+      {rules.mode === 'zen' && <div>Zen Mode</div>}
     </div>
   );
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -13,5 +13,5 @@ export interface Rules {
   challengeMode: boolean;
   noRepeats: boolean;
   timer: boolean;
-  mode: 'bot' | 'multi';
+  mode: 'bot' | 'multi' | 'zen';
 }

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -31,7 +31,7 @@ interface GameState {
   roll(): void;
   submitWord(
     word: string,
-    useWildcard?: boolean
+    useWildcard?: boolean,
   ): { accepted: boolean; reason?: string };
   endTurn(): void;
   muted: boolean;
@@ -124,12 +124,14 @@ export const useGameStore = create<GameState>((set, get) => ({
     return { accepted: true };
   },
   endTurn() {
-    set((s) => ({
-      current: s.current === 0 ? 1 : 0,
-      requiredLength: 0,
-    }));
     const state = get();
-    if (state.rules.mode === 'bot' && state.current === 1) {
+    if (state.rules.mode === 'zen') {
+      set({ requiredLength: 0 });
+      return;
+    }
+    set({ current: state.current === 0 ? 1 : 0, requiredLength: 0 });
+    const after = get();
+    if (after.rules.mode === 'bot' && after.current === 1) {
       get().roll();
       const aiState = get();
       const word = chooseRandomWord({

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -64,7 +64,13 @@ describe('game store', () => {
     expect(useGameStore.getState().current).toBe(1);
   });
 
-  it('AI plays automatically in single mode', () => {
+  it('zen mode keeps turn with player 1', () => {
+    useGameStore.getState().newGame({ mode: 'zen' });
+    useGameStore.getState().endTurn();
+    expect(useGameStore.getState().current).toBe(0);
+  });
+
+  it('AI plays automatically in bot mode', () => {
     useGameStore.getState().newGame({ mode: 'bot' });
     useGameStore.setState({ dictionary: dict, startLetter: 'a' });
     const rollSpy = vi.spyOn(diceModule, 'rollDie').mockReturnValue(5);


### PR DESCRIPTION
## Summary
- Add `zen` mode to rules and game store for a solo experience without AI
- Update setup modal, board, HUD, and summary to expose Zen Mode and hide second player
- Adjust tests and logic so bot mode is distinct from Zen Mode

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68acbe56bd088324acbc1b30f1aa6e81