### PR TITLE
feat: announce winner when game is complete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import GameSetupModal from './components/GameSetupModal';
 export default function App() {
   const setDictionary = useGameStore((s) => s.setDictionary);
   const newGame = useGameStore((s) => s.newGame);
+  const winner = useGameStore((s) => s.winner);
   const [dictError, setDictError] = useState<string | null>(null);
   const [dictLoading, setDictLoading] = useState(true);
   const [showSetup, setShowSetup] = useState(true);
@@ -51,6 +52,14 @@ export default function App() {
           <button className="underline" onClick={loadDict} type="button">
             Retry
           </button>
+        </div>
+      )}
+      {winner !== null && (
+        <div
+          role="status"
+          className="p-2 bg-green-100 border border-green-400 text-green-700 text-center rounded"
+        >
+          Player {winner + 1} wins!
         </div>
       )}
       {!dictLoading && !dictError && (

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -70,6 +70,20 @@ describe('game store', () => {
     expect(useGameStore.getState().current).toBe(0);
   });
 
+  it('identifies winner and prevents further moves', () => {
+    useGameStore.getState().newGame({ boardSize: 10, snakes: [], ladders: [] });
+    useGameStore.setState({ dictionary: dict, requiredLength: 9, startLetter: 'a' });
+    const res = useGameStore.getState().submitWord('aardvarks');
+    expect(res.accepted).toBe(true);
+    const state = useGameStore.getState();
+    expect(state.positions[0]).toBe(9);
+    expect(state.winner).toBe(0);
+    useGameStore.getState().roll();
+    expect(useGameStore.getState().lastDie).toBe(0);
+    useGameStore.getState().endTurn();
+    expect(useGameStore.getState().current).toBe(0);
+  });
+
   it('AI plays automatically in bot mode', () => {
     useGameStore.getState().newGame({ mode: 'bot' });
     useGameStore.setState({ dictionary: dict, startLetter: 'a' });


### PR DESCRIPTION
## Summary
- track `winner` in game store and stop further actions after victory
- display a banner announcing the winning player
- test win condition to ensure turns and rolls cease after a win

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc606bf008324993dcd0a96522b87