### PR TITLE
docs: add inline comments across project

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,12 +1,19 @@
+// ESLint configuration enforcing code quality and style rules
 module.exports = {
   root: true,
+  // Parse TypeScript files
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'react'],
   extends: [
+    // Base recommended rules
     'eslint:recommended',
+    // Additional rules for TypeScript
     'plugin:@typescript-eslint/recommended',
+    // React-specific linting
     'plugin:react/recommended',
+    // Allow automatic runtime for JSX
     'plugin:react/jsx-runtime',
+    // Integrate with Prettier formatting
     'prettier',
   ],
   env: {
@@ -16,6 +23,7 @@ module.exports = {
   },
   settings: {
     react: {
+      // Automatically detect installed React version
       version: 'detect',
     },
   },

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Basic metadata and PWA setup -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -12,7 +13,9 @@
     <title>Snakes & Letters</title>
   </head>
   <body class="bg-gray-100 text-gray-900 font-sans">
+    <!-- Root div where React mounts -->
     <div id="root"></div>
+    <!-- Entry point for the application -->
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,9 @@
+// PostCSS configuration to process Tailwind and add vendor prefixes
 module.exports = {
   plugins: {
+    // Generates Tailwind utility classes
     tailwindcss: {},
+    // Adds vendor prefixes for broader browser support
     autoprefixer: {},
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
+// Core game components
 import Board from './components/Board';
 import WordInput from './components/WordInput';
 import HUD from './components/HUD';
 import ModeSummary from './components/ModeSummary';
+// Helper utilities and state store
 import { loadWordlist } from './dictionary/loader';
 import { useGameStore } from './store/useGameStore';
 import GameSetupModal from './components/GameSetupModal';
@@ -15,6 +17,7 @@ export default function App() {
   const [dictLoading, setDictLoading] = useState(true);
   const [showSetup, setShowSetup] = useState(true);
 
+  // Loads dictionary data and stores it in state
   const loadDict = useCallback(() => {
     setDictLoading(true);
     setDictError(null);
@@ -32,6 +35,7 @@ export default function App() {
       .finally(() => setDictLoading(false));
   }, [setDictionary]);
 
+  // Fetch dictionary on initial mount
   useEffect(() => {
     void loadDict();
   }, [loadDict]);
@@ -65,6 +69,7 @@ export default function App() {
       {!dictLoading && !dictError && (
         <>
           {showSetup ? (
+            // Initial setup modal before starting the game
             <GameSetupModal
               onStart={(opts) => {
                 newGame(opts);

--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,2 @@
+/* Import compiled Tailwind styles */
 @import './styles/tailwind.css';

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,3 +1,4 @@
+// Renders the game board grid and decorative snakes and ladders
 import { useGameStore } from '../store/useGameStore';
 import Cell from './Cell';
 import { indexToPosition } from '../engine/board';
@@ -8,6 +9,7 @@ export default function Board() {
   const width = Math.round(Math.sqrt(rules.boardSize));
   const cellSize = 100 / width;
   const cells: JSX.Element[] = [];
+  // Build serpentine board layout
   for (let row = width - 1; row >= 0; row--) {
     for (let col = 0; col < width; col++) {
       const index = row * width + (row % 2 === 0 ? col : width - 1 - col);
@@ -23,6 +25,7 @@ export default function Board() {
     }
   }
 
+  // Merge snakes and ladders into decorative lines on the board
   const decorations = [
     ...rules.snakes.map((s) => ({ ...s, type: 'snake' })),
     ...rules.ladders.map((l) => ({ ...l, type: 'ladder' })),

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,3 +1,4 @@
+// Individual board cell that can display player tokens and letters
 import { PlayerId } from '../store/useGameStore';
 import { motion } from 'framer-motion';
 import type { Rules } from '../engine';
@@ -12,6 +13,7 @@ interface CellProps {
 export default function Cell({ index, positions, letter, mode }: CellProps) {
   const tokens: JSX.Element[] = [];
 
+  // Render player one token if on this cell
   if (positions[0] === index) {
     tokens.push(
       <motion.img
@@ -25,6 +27,7 @@ export default function Cell({ index, positions, letter, mode }: CellProps) {
     );
   }
 
+  // Only show second player when not in single-player mode
   if (mode !== 'zen' && positions[1] === index) {
     tokens.push(
       <motion.img

--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -1,3 +1,4 @@
+// Visual dice component that can be rolled to produce a value
 import { useEffect, useRef } from 'react';
 import { useGameStore } from '../store/useGameStore';
 
@@ -30,6 +31,7 @@ export default function Dice({ value }: DiceProps) {
       className="w-12 h-12 border rounded flex items-center justify-center text-2xl bg-secondary text-white"
       onClick={() => {
         roll();
+        // Play sound effect when not muted
         if (!muted) rollSound.current?.play();
       }}
       aria-label="Roll die"

--- a/src/components/GameSetupModal.tsx
+++ b/src/components/GameSetupModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+// Options chosen in the setup screen
 type SetupOptions = {
   boardSize: number;
   challengeMode: boolean;
@@ -86,6 +87,7 @@ export default function GameSetupModal({ onStart }: Props) {
             Play vs Bot
           </label>
         </div>
+        {/* Start button initializes game with selected options */}
         <button
           type="button"
           className="w-full bg-blue-500 text-white py-1 rounded"

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,3 +1,4 @@
+// Heads-up display showing game stats and controls
 import Dice from './Dice';
 import { useGameStore } from '../store/useGameStore';
 
@@ -7,6 +8,7 @@ export default function HUD() {
   return (
     <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
       <Dice />
+      {/* Display current turn information */}
       <div>Required: {requiredLength || '-'}</div>
       <div>Start: {startLetter}</div>
       <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>

--- a/src/components/ModeSummary.tsx
+++ b/src/components/ModeSummary.tsx
@@ -1,3 +1,4 @@
+// Displays active mode and rule toggles for quick reference
 import { useGameStore } from '../store/useGameStore';
 
 export default function ModeSummary() {
@@ -7,6 +8,7 @@ export default function ModeSummary() {
       <h2 className="font-bold text-base">Modes</h2>
       <div>{rules.challengeMode ? 'Challenge' : 'Easy'}</div>
       <div>{rules.noRepeats ? 'No Repeats' : 'Repeats Allowed'}</div>
+      {/* Conditionally show extra mode indicators */}
       {rules.timer && <div>Timer Enabled</div>}
       {rules.mode === 'bot' && <div>Vs Bot</div>}
       {rules.mode === 'zen' && <div>Zen Mode</div>}

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -1,3 +1,4 @@
+// Toolbar allowing the user to toggle various game options
 import { useGameStore } from '../store/useGameStore';
 import type { ChangeEvent } from 'react';
 
@@ -34,6 +35,7 @@ export default function ToggleBar() {
           <option value={12}>12×12</option>
         </select>
       </div>
+      {/* Toggle challenge mode */}
       <div className="flex items-center space-x-1">
         <input
           id="toggle-challenge"
@@ -43,6 +45,7 @@ export default function ToggleBar() {
         />
         <label htmlFor="toggle-challenge">Challenge</label>
       </div>
+      {/* Toggle no-repeats rule */}
       <div className="flex items-center space-x-1">
         <input
           id="toggle-no-repeats"
@@ -52,6 +55,7 @@ export default function ToggleBar() {
         />
         <label htmlFor="toggle-no-repeats">No Repeats</label>
       </div>
+      {/* Toggle turn timer */}
       <div className="flex items-center space-x-1">
         <input
           id="toggle-timer"
@@ -61,6 +65,7 @@ export default function ToggleBar() {
         />
         <label htmlFor="toggle-timer">Timer</label>
       </div>
+      {/* Toggle sound effects */}
       <div className="flex items-center space-x-1">
         <input
           id="toggle-mute"

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -1,3 +1,4 @@
+// Handles player word entry, validation and hints
 import { useEffect, useRef, useState } from 'react';
 import { useGameStore } from '../store/useGameStore';
 import { validateWord } from '../engine/validate';
@@ -27,6 +28,7 @@ export default function WordInput() {
     current,
   } = useGameStore();
 
+  // Check if current input is valid according to game rules
   const validation = validateWord(word, {
     length: requiredLength,
     startLetter,
@@ -82,6 +84,7 @@ export default function WordInput() {
             }
           }}
         />
+        {/* Optionally bypass starting letter rule */}
         <label htmlFor="use-wildcard" className="flex items-center space-x-1">
           <input
             id="use-wildcard"

--- a/src/dictionary/index.ts
+++ b/src/dictionary/index.ts
@@ -1,1 +1,2 @@
+// Re-export dictionary loader utilities
 export * from './loader';

--- a/src/dictionary/loader.ts
+++ b/src/dictionary/loader.ts
@@ -1,6 +1,7 @@
 // Keep the current public API shape for minimal churn.
 export type Dictionary = Set<string>;
 
+// Convert raw word list text into a normalized set of lowercase words
 function normalize(text: string): Dictionary {
   return new Set(
     text
@@ -64,10 +65,12 @@ export async function loadWordlist(
   throw new Error('Failed to load dictionary');
 }
 
+// Check for existence of a word in the dictionary
 export function hasWord(dict: Dictionary, word: string): boolean {
   return dict.has(word.toLowerCase());
 }
 
+// Return a small list of candidate words matching the criteria
 export function getHints(
   dict: Dictionary,
   startLetter: string,

--- a/src/engine/ai.ts
+++ b/src/engine/ai.ts
@@ -1,3 +1,4 @@
+// Parameters used by the simple AI to select a word
 interface AiParams {
   dictionary: Set<string>;
   length: number;
@@ -6,6 +7,7 @@ interface AiParams {
   noRepeats: boolean;
 }
 
+// Randomly choose a valid word for the AI
 export function chooseRandomWord({
   dictionary,
   length,

--- a/src/engine/board.ts
+++ b/src/engine/board.ts
@@ -1,12 +1,15 @@
+// Board-related helpers: coordinate conversions and snake/ladder generation
 import { CellIndex, Rules, SnakeOrLadder } from './types';
 import { randomInt } from '../utils/random';
 
+// Ensure an index stays within board bounds
 export function clampIndex(i: CellIndex, boardSize: number): CellIndex {
   if (i < 0) return 0;
   if (i >= boardSize) return boardSize - 1;
   return i;
 }
 
+// Convert a linear cell index into board row/column coordinates
 export function indexToPosition(
   i: CellIndex,
   boardSize: number,
@@ -19,9 +22,10 @@ export function indexToPosition(
   return { row, col };
 }
 
+// Follow chains of snakes or ladders until a stable cell is reached
 export function resolveSnakesAndLadders(
   index: CellIndex,
-  rules: Rules
+  rules: Rules,
 ): CellIndex {
   let current = index;
   const visited = new Set<CellIndex>();
@@ -45,6 +49,7 @@ export function resolveSnakesAndLadders(
   return Math.min(current, last);
 }
 
+// Procedurally create random snakes and ladders for a board
 export function generateSnakesAndLadders(
   boardSize: number,
   snakeCount = 4,

--- a/src/engine/dice.ts
+++ b/src/engine/dice.ts
@@ -1,3 +1,4 @@
+// Simple seeded random number generator for deterministic dice rolls
 export class RNG {
   private seed: number;
   constructor(seed = Date.now()) {
@@ -9,6 +10,7 @@ export class RNG {
   }
 }
 
+// Roll a die using optional RNG; returns values 3-6
 export function rollDie(rng?: RNG): number {
   const r = rng ? rng.next() : Math.random();
   // Die now ranges 3-6 to avoid one- or two-letter rounds

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,3 +1,4 @@
+// Convenience re-exports for engine modules
 export * from './types';
 export * from './board';
 export * from './rules';

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -1,3 +1,4 @@
+// Default rule set defining board size and obstacles
 import { Rules } from './types';
 
 export const defaultRules: Rules = {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,10 +1,13 @@
+// Board cell index represented as a number
 export type CellIndex = number;
 
+// Mapping from one cell to another for snakes or ladders
 export interface SnakeOrLadder {
   from: CellIndex;
   to: CellIndex;
 }
 
+// Game rules configuring board and gameplay options
 export interface Rules {
   boardSize: number;
   snakes: SnakeOrLadder[];

--- a/src/engine/validate.ts
+++ b/src/engine/validate.ts
@@ -1,5 +1,7 @@
+// Word validation utilities used by the game engine
 import type { Dictionary } from '../dictionary/loader';
 
+// Normalize player input for consistent comparisons
 export function normalize(word: string): string {
   return word.trim().toLowerCase();
 }
@@ -14,9 +16,10 @@ interface Options {
   canSatisfy?: (letter: string, length: number) => boolean;
 }
 
+// Validate a word against length, starting letter and dictionary rules
 export function validateWord(
   word: string,
-  opts: Options
+  opts: Options,
 ): { accepted: boolean; reason?: string } {
   const w = normalize(word);
   if (w.length !== opts.length) {
@@ -36,10 +39,11 @@ export function validateWord(
   return { accepted: true };
 }
 
+// Determine if any dictionary word fits the criteria
 export function canSatisfy(
   letter: string,
   length: number,
-  dict: Dictionary
+  dict: Dictionary,
 ): boolean {
   const lower = letter.toLowerCase();
   for (const word of dict) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,10 @@ import App from './App';
 import './app.css';
 import { registerSW } from './pwa/registerSW';
 
+// Register the service worker for PWA capabilities
 registerSW();
 
+// Mount the React application to the DOM
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/pwa/registerSW.ts
+++ b/src/pwa/registerSW.ts
@@ -1,3 +1,4 @@
+// Register the service worker when supported
 export function registerSW() {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {

--- a/src/pwa/service-worker.ts
+++ b/src/pwa/service-worker.ts
@@ -1,3 +1,4 @@
+// Service worker implementing basic offline caching
 declare const self: ServiceWorkerGlobalScope;
 
 const CACHE = 'snakes-letters-v1';
@@ -13,7 +14,10 @@ const ASSETS = [
 
 self.addEventListener('install', (event: ExtendableEvent) => {
   event.waitUntil(
-    caches.open(CACHE).then((c) => c.addAll(ASSETS)).then(() => self.skipWaiting())
+    caches
+      .open(CACHE)
+      .then((c) => c.addAll(ASSETS))
+      .then(() => self.skipWaiting()),
   );
 });
 
@@ -23,6 +27,6 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 
 self.addEventListener('fetch', (event: FetchEvent) => {
   event.respondWith(
-    caches.match(event.request).then((resp) => resp || fetch(event.request))
+    caches.match(event.request).then((resp) => resp || fetch(event.request)),
   );
 });

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+// Core engine helpers and types
 import {
   Rules,
   CellIndex,
@@ -15,6 +16,7 @@ import type { Dictionary } from '../dictionary/loader';
 
 export type PlayerId = 0 | 1;
 
+// State and actions managed by Zustand
 interface GameState {
   rules: Rules;
   positions: Record<PlayerId, CellIndex>;
@@ -55,6 +57,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   setDictionary(dict) {
     set({ dictionary: dict });
   },
+  // Start a new game optionally overriding rules
   newGame(rules) {
     const merged: Rules = { ...defaultRules, ...rules };
     if (
@@ -80,11 +83,13 @@ export const useGameStore = create<GameState>((set, get) => ({
       winner: null,
     });
   },
+  // Roll the die to determine required word length
   roll() {
     if (get().winner !== null) return;
     const die = rollDie();
     set({ lastDie: die, requiredLength: die });
   },
+  // Validate and apply a submitted word
   submitWord(word, useWildcard = false) {
     const state = get();
     if (state.winner !== null) {
@@ -132,6 +137,7 @@ export const useGameStore = create<GameState>((set, get) => ({
     });
     return { accepted: true };
   },
+  // Advance to next player's turn or trigger AI
   endTurn() {
     const state = get();
     if (state.winner !== null) {
@@ -159,6 +165,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       set({ current: 0, requiredLength: 0 });
     }
   },
+  // Toggle sound effects on/off
   toggleMute() {
     set((s) => ({ muted: !s.muted }));
   },

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,4 @@
+/* Tailwind layers to generate base styles and utilities */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,3 +1,4 @@
+// Utility helper to get an integer in [0, max)
 export function randomInt(max: number): number {
   return Math.floor(Math.random() * max);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,17 +1,22 @@
+// Tailwind configuration defining theme extensions and source files
 import type { Config } from 'tailwindcss';
 
 export default {
+  // Files to scan for class names
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {
       colors: {
+        // Custom brand colors used throughout the UI
         primary: '#4a90e2',
         secondary: '#f5a623',
       },
       fontFamily: {
+        // Use Inter as the default sans-serif font
         sans: ['Inter', 'sans-serif'],
       },
     },
   },
+  // No additional plugins are required for the basic setup
   plugins: [],
 } satisfies Config;

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+// Board utility functions under test
 import {
   indexToPosition,
   clampIndex,

--- a/tests/dictionary-loader.test.ts
+++ b/tests/dictionary-loader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+// Loader module under test
 import { loadWordlist } from '../src/dictionary/loader';
 
 describe('loadWordlist retries', () => {

--- a/tests/hints.test.ts
+++ b/tests/hints.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+// Dictionary hint helper under test
 import { getHints, Dictionary } from '../src/dictionary/loader';
 
 describe('getHints', () => {

--- a/tests/snakes-ladders.test.ts
+++ b/tests/snakes-ladders.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+// Test the snake and ladder resolution logic
 import { resolveSnakesAndLadders } from '../src/engine/board';
 import { Rules } from '../src/engine/types';
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+// State store and helpers under test
 import { useGameStore } from '../src/store/useGameStore';
 import { loadWordlist } from '../src/dictionary/loader';
 import * as diceModule from '../src/engine/dice';

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+// Validation helpers under test
 import { validateWord } from '../src/engine/validate';
 import { loadWordlist, hasWord } from '../src/dictionary/loader';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,12 @@
+// Vite configuration enabling React and Vitest
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  // Register the React plugin for JSX/TSX support
   plugins: [react()],
   test: {
+    // Use jsdom to simulate the browser for tests
     environment: 'jsdom',
     globals: true,
   },


### PR DESCRIPTION
## Summary
- document board and engine helpers with inline comments
- clarify store logic and component usage via comments
- annotate tests and configs for readability

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acca0a50808324bf4a16a724c9e523