### PR TITLE
refactor: resize-aware board and UI column adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 // Core game components
 import Board from './components/Board';
 import WordInput from './components/WordInput';
@@ -16,6 +16,8 @@ export default function App() {
   const [dictError, setDictError] = useState<string | null>(null);
   const [dictLoading, setDictLoading] = useState(true);
   const [showSetup, setShowSetup] = useState(true);
+  const [boardHeight, setBoardHeight] = useState(0);
+  const boardRef = useRef<HTMLDivElement>(null);
 
   // Loads dictionary data and stores it in state
   const loadDict = useCallback(() => {
@@ -39,6 +41,17 @@ export default function App() {
   useEffect(() => {
     void loadDict();
   }, [loadDict]);
+
+  // Track board size to sync side column heights
+  useEffect(() => {
+    if (!boardRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect;
+      setBoardHeight(rect.height);
+    });
+    ro.observe(boardRef.current);
+    return () => ro.disconnect();
+  }, []);
 
   return (
     <div className="p-4 space-y-4 mx-auto">
@@ -79,11 +92,18 @@ export default function App() {
           ) : (
             <>
               <div className="flex gap-4 items-start justify-center">
-                <ModeSummary />
-                <Board />
-                <HUD />
+                <div
+                  className="flex flex-col justify-between"
+                  style={{ height: boardHeight }}
+                >
+                  <ModeSummary />
+                  <WordInput />
+                </div>
+                <Board boardRef={boardRef} />
+                <div style={{ height: boardHeight }}>
+                  <HUD />
+                </div>
               </div>
-              <WordInput />
             </>
           )}
         </>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -8,10 +8,12 @@ interface CellProps {
   positions: Record<PlayerId, number>;
   letter?: string;
   mode: Rules['mode'];
+  boardWidth: number;
 }
 
-export default function Cell({ index, positions, letter, mode }: CellProps) {
+export default function Cell({ index, positions, letter, mode, boardWidth }: CellProps) {
   const tokens: JSX.Element[] = [];
+  const unit = 90 / boardWidth; // vmin per cell
 
   // Render player one token if on this cell
   if (positions[0] === index) {
@@ -21,7 +23,13 @@ export default function Cell({ index, positions, letter, mode }: CellProps) {
         key="p1"
         src="/assets/redpawn.svg"
         alt="P1"
-        className="absolute top-1 right-1 w-4 h-4"
+        className="absolute"
+        style={{
+          width: `${unit * 0.4}vmin`,
+          height: `${unit * 0.4}vmin`,
+          top: `${unit * 0.1}vmin`,
+          right: `${unit * 0.1}vmin`,
+        }}
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />,
     );
@@ -35,7 +43,13 @@ export default function Cell({ index, positions, letter, mode }: CellProps) {
         key="p2"
         src="/assets/bluepawn.svg"
         alt="P2"
-        className="absolute bottom-1 right-1 w-4 h-4"
+        className="absolute"
+        style={{
+          width: `${unit * 0.4}vmin`,
+          height: `${unit * 0.4}vmin`,
+          bottom: `${unit * 0.1}vmin`,
+          right: `${unit * 0.1}vmin`,
+        }}
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />,
     );
@@ -43,8 +57,17 @@ export default function Cell({ index, positions, letter, mode }: CellProps) {
 
   return (
     <div className="relative w-full aspect-square border flex items-center justify-center">
-      <span className="absolute top-1 left-1 text-[0.5rem]">{index + 1}</span>
-      <span className="text-[clamp(0.5rem,2vmin,1.25rem)]">{letter}</span>
+      <span
+        className="absolute"
+        style={{
+          top: `${unit * 0.1}vmin`,
+          left: `${unit * 0.1}vmin`,
+          fontSize: `${unit * 0.25}vmin`,
+        }}
+      >
+        {index + 1}
+      </span>
+      <span style={{ fontSize: `${unit * 0.5}vmin` }}>{letter}</span>
       {tokens}
     </div>
   );


### PR DESCRIPTION
## Summary
- scale cell content and pawn tokens based on board size
- move word entry to left column and sync side columns with board height
- thicken snakes and ladders, add snake eye and ladder rungs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ad84c295e88324a29f13b6e61af15a