### PR TITLE
Highlight current player's cell on board

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -10,7 +10,7 @@ interface BoardProps {
 }
 
 export default function Board({ boardRef }: BoardProps) {
-  const { positions, rules, boardLetters } = useGameStore();
+  const { positions, rules, boardLetters, current } = useGameStore();
   const width = Math.round(Math.sqrt(rules.boardSize));
   const cellSize = 100 / width;
   const cells: JSX.Element[] = [];
@@ -23,6 +23,7 @@ export default function Board({ boardRef }: BoardProps) {
           key={index}
           index={index}
           positions={positions}
+          current={current}
           letter={boardLetters[index]}
           mode={rules.mode}
           boardWidth={width}

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -6,14 +6,16 @@ import type { Rules } from '../engine';
 interface CellProps {
   index: number;
   positions: Record<PlayerId, number>;
+  current: PlayerId;
   letter?: string;
   mode: Rules['mode'];
   boardWidth: number;
 }
 
-export default function Cell({ index, positions, letter, mode, boardWidth }: CellProps) {
+export default function Cell({ index, positions, current, letter, mode, boardWidth }: CellProps) {
   const tokens: JSX.Element[] = [];
   const unit = 90 / boardWidth; // vmin per cell
+  const isCurrent = index === positions[current];
 
   // Render player one token if on this cell
   if (positions[0] === index) {
@@ -56,7 +58,11 @@ export default function Cell({ index, positions, letter, mode, boardWidth }: Cel
   }
 
   return (
-    <div className="relative w-full aspect-square border flex items-center justify-center">
+    <div
+      className={`relative w-full aspect-square border flex items-center justify-center ${
+        isCurrent ? 'bg-yellow-100 ring-4 ring-yellow-400' : ''
+      }`}
+    >
       <span
         className="absolute"
         style={{


### PR DESCRIPTION
## Summary
- Pass current player from store into each Cell
- Highlight the active cell for the current player with a ring and background

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad8aa755b08324b6186e454b80508b