### PR TITLE
Add per-turn timer with automatic turn end

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,10 +1,34 @@
 // Heads-up display showing game stats and controls
+import { useEffect } from 'react';
 import Dice from './Dice';
 import { useGameStore } from '../store/useGameStore';
 
 export default function HUD() {
-  const { requiredLength, startLetter, wildcards, current, positions, rules } =
-    useGameStore();
+  const {
+    requiredLength,
+    startLetter,
+    wildcards,
+    current,
+    positions,
+    rules,
+    remainingTime,
+  } = useGameStore();
+  const decrementTimer = useGameStore((s) => s.decrementTimer);
+  const endTurn = useGameStore((s) => s.endTurn);
+
+  useEffect(() => {
+    if (!rules.timer || !requiredLength) return;
+    const id = setInterval(() => {
+      decrementTimer();
+    }, 1000);
+    return () => clearInterval(id);
+  }, [rules.timer, requiredLength, decrementTimer]);
+
+  useEffect(() => {
+    if (rules.timer && requiredLength && remainingTime === 0) {
+      endTurn();
+    }
+  }, [rules.timer, requiredLength, remainingTime, endTurn]);
   return (
     <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
       <Dice />
@@ -13,6 +37,7 @@ export default function HUD() {
       <div>Start: {startLetter}</div>
       <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>
       <div>Wildcards: {wildcards[current]}</div>
+      {rules.timer && <div>Time: {remainingTime || '-'}</div>}
       <div className="pt-2">
         <div className={current === 0 ? 'font-bold' : ''}>
           P1: {positions[0]}


### PR DESCRIPTION
## Summary
- track `remainingTime` in game store and reset it when rolling
- tick timer in HUD and auto-end turns on expiry
- show remaining seconds while timer rule is active

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8d3166a4832499ad5abfdfc5d388