### PR TITLE
Auto-roll dice and refine endgame logic

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -78,7 +78,7 @@ export default function Board({ boardRef }: BoardProps) {
       return elements;
     }
 
-    // Ladder with rails and rungs
+    // Ladder with vertical rails and horizontal rungs
     const thickness = cellSize * 0.3;
     const stepCount = Math.max(2, Math.floor(length / cellSize));
     return (
@@ -88,19 +88,19 @@ export default function Board({ boardRef }: BoardProps) {
         style={{
           left: `${x}%`,
           top: `${y}%`,
-          width: `${length}%`,
-          height: `${thickness}%`,
-          transform: `translateY(-50%) rotate(${angle}deg)`,
-          transformOrigin: '0% 50%',
+          width: `${thickness}%`,
+          height: `${length}%`,
+          transform: `translateX(-50%) rotate(${angle}deg)`,
+          transformOrigin: '50% 0%',
         }}
       >
         <span
           className="absolute bg-yellow-500"
-          style={{ left: 0, top: 0, bottom: 0, width: '20%' }}
+          style={{ top: 0, bottom: 0, left: 0, width: '30%' }}
         />
         <span
           className="absolute bg-yellow-500"
-          style={{ right: 0, top: 0, bottom: 0, width: '20%' }}
+          style={{ top: 0, bottom: 0, right: 0, width: '30%' }}
         />
         {Array.from({ length: stepCount }).map((_, j) => (
           <span

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -9,7 +9,6 @@ export default function HUD() {
     startLetter,
     wildcards,
     current,
-    positions,
     rules,
     remainingTime,
   } = useGameStore();
@@ -38,16 +37,6 @@ export default function HUD() {
       <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>
       <div>Wildcards: {wildcards[current]}</div>
       {rules.timer && <div>Time: {remainingTime || '-'}</div>}
-      <div className="pt-2">
-        <div className={current === 0 ? 'font-bold' : ''}>
-          P1: {positions[0]}
-        </div>
-        {rules.mode !== 'zen' && (
-          <div className={current === 1 ? 'font-bold' : ''}>
-            P2: {positions[1]}
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -57,6 +57,9 @@ export default function WordInput() {
       setUseWildcard(false);
       endTurn();
     }
+    if (res.reason === 'overshoot') {
+      alert('Word exceeds remaining squares. Turn skipped.');
+    }
   };
 
   const canUseWildcard = wildcards[current] > 0;
@@ -102,6 +105,17 @@ export default function WordInput() {
           aria-label="Submit word"
         >
           Submit
+        </button>
+        <button
+          type="button"
+          className="border px-2 rounded"
+          onClick={() => {
+            setWord('');
+            setUseWildcard(false);
+            endTurn();
+          }}
+        >
+          Concede
         </button>
         <button
           type="button"

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -29,7 +29,7 @@ describe('game store', () => {
     useGameStore.setState({ requiredLength: 5 });
     const res = useGameStore.getState().submitWord('apple');
     expect(res.accepted).toBe(true);
-    expect(useGameStore.getState().positions[0]).toBe(5);
+    expect(useGameStore.getState().positions[0]).toBe(4);
     expect(useGameStore.getState().startLetter).toBe('e');
   });
 
@@ -73,14 +73,19 @@ describe('game store', () => {
 
   it('identifies winner and prevents further moves', () => {
     useGameStore.getState().newGame({ boardSize: 10, snakes: [], ladders: [] });
-    useGameStore.setState({ dictionary: dict, requiredLength: 9, startLetter: 'a' });
-    const res = useGameStore.getState().submitWord('aardvarks');
+    useGameStore.setState({
+      dictionary: dict,
+      requiredLength: 10,
+      startLetter: 'a',
+    });
+    const res = useGameStore.getState().submitWord('abandoning');
     expect(res.accepted).toBe(true);
     const state = useGameStore.getState();
     expect(state.positions[0]).toBe(9);
     expect(state.winner).toBe(0);
+    const prev = useGameStore.getState().lastDie;
     useGameStore.getState().roll();
-    expect(useGameStore.getState().lastDie).toBe(0);
+    expect(useGameStore.getState().lastDie).toBe(prev);
     useGameStore.getState().endTurn();
     expect(useGameStore.getState().current).toBe(0);
   });
@@ -94,7 +99,7 @@ describe('game store', () => {
       .mockReturnValue('apple');
     useGameStore.getState().endTurn();
     expect(aiSpy).toHaveBeenCalled();
-    expect(useGameStore.getState().positions[1]).toBe(5);
+    expect(useGameStore.getState().positions[1]).toBe(4);
     expect(useGameStore.getState().startLetter).toBe('e');
     expect(useGameStore.getState().current).toBe(0);
     rollSpy.mockRestore();


### PR DESCRIPTION
## Summary
- auto-roll dice each turn with 3s spin and overshoot check
- allow players to concede and skip when rolls exceed remaining squares
- start new words on the same tile and clean up HUD/ladder visuals

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68adbf6b56f88324b42b18396bc199dc