### PR TITLE
Fix word movement distance and update tests

### DIFF
--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -125,7 +125,9 @@ export const useGameStore = create<GameState>((set, get) => ({
       }
       return validation;
     }
-    const move = normalized.length - 1;
+    // Move forward by the full length of the accepted word. The board is
+    // zero-indexed, so a five-letter word moves the player from cell 0 to 5.
+    const move = normalized.length;
     const remaining =
       state.rules.boardSize - 1 - state.positions[state.current];
     if (move > remaining) {
@@ -140,8 +142,11 @@ export const useGameStore = create<GameState>((set, get) => ({
     const newWildcards = { ...state.wildcards };
     if (useWildcard) newWildcards[state.current]--;
     const letters = [...state.boardLetters];
+    // Place the letters along the path the player travelled, starting with
+    // the cell immediately after the starting position so the final letter
+    // lands on the destination cell.
     for (let i = 0; i < normalized.length; i++) {
-      const idx = state.positions[state.current] + i;
+      const idx = state.positions[state.current] + i + 1;
       if (idx < letters.length) letters[idx] = normalized[i];
     }
     const win = position === state.rules.boardSize - 1;

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -29,7 +29,7 @@ describe('game store', () => {
     useGameStore.setState({ requiredLength: 5 });
     const res = useGameStore.getState().submitWord('apple');
     expect(res.accepted).toBe(true);
-    expect(useGameStore.getState().positions[0]).toBe(4);
+    expect(useGameStore.getState().positions[0]).toBe(5);
     expect(useGameStore.getState().startLetter).toBe('e');
   });
 
@@ -75,10 +75,10 @@ describe('game store', () => {
     useGameStore.getState().newGame({ boardSize: 10, snakes: [], ladders: [] });
     useGameStore.setState({
       dictionary: dict,
-      requiredLength: 10,
+      requiredLength: 9,
       startLetter: 'a',
     });
-    const res = useGameStore.getState().submitWord('abandoning');
+    const res = useGameStore.getState().submitWord('abandoned');
     expect(res.accepted).toBe(true);
     const state = useGameStore.getState();
     expect(state.positions[0]).toBe(9);
@@ -99,7 +99,7 @@ describe('game store', () => {
       .mockReturnValue('apple');
     useGameStore.getState().endTurn();
     expect(aiSpy).toHaveBeenCalled();
-    expect(useGameStore.getState().positions[1]).toBe(4);
+    expect(useGameStore.getState().positions[1]).toBe(5);
     expect(useGameStore.getState().startLetter).toBe('e');
     expect(useGameStore.getState().current).toBe(0);
     rollSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Move players by full word length and document the behavior
- Lay letters on the traversed path so the destination cell shows the final letter
- Update store tests for new movement rule and winning scenario

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68adc240715883248718666eef93e9bc