### PR TITLE
Start players outside the board

### DIFF
--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -47,7 +47,7 @@ interface GameState {
 
 export const useGameStore = create<GameState>((set, get) => ({
   rules: defaultRules,
-  positions: { 0: 0, 1: 0 },
+  positions: { 0: -1, 1: -1 },
   current: 0,
   lastDie: 0,
   startLetter: String.fromCharCode(97 + Math.floor(Math.random() * 26)),
@@ -77,7 +77,7 @@ export const useGameStore = create<GameState>((set, get) => ({
     }
     set({
       rules: merged,
-      positions: { 0: 0, 1: 0 },
+      positions: { 0: -1, 1: -1 },
       current: 0,
       lastDie: 0,
       startLetter: String.fromCharCode(97 + Math.floor(Math.random() * 26)),
@@ -118,15 +118,16 @@ export const useGameStore = create<GameState>((set, get) => ({
     if (!validation.accepted) {
       if (state.rules.challengeMode) {
         let pos = state.positions[state.current] - state.lastDie;
-        pos = clampIndex(pos, state.rules.boardSize);
+        pos = Math.max(pos, -1);
         set({
           positions: { ...state.positions, [state.current]: pos },
         });
       }
       return validation;
     }
-    // Move forward by the full length of the accepted word. The board is
-    // zero-indexed, so a five-letter word moves the player from cell 0 to 5.
+    // Move forward by the full length of the accepted word. Players start
+    // off-board at index -1, so a five-letter word lands on cell 4
+    // (the board itself remains zero-indexed).
     const move = normalized.length;
     const remaining =
       state.rules.boardSize - 1 - state.positions[state.current];

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -29,7 +29,7 @@ describe('game store', () => {
     useGameStore.setState({ requiredLength: 5 });
     const res = useGameStore.getState().submitWord('apple');
     expect(res.accepted).toBe(true);
-    expect(useGameStore.getState().positions[0]).toBe(5);
+    expect(useGameStore.getState().positions[0]).toBe(4);
     expect(useGameStore.getState().startLetter).toBe('e');
   });
 
@@ -44,7 +44,7 @@ describe('game store', () => {
     useGameStore.setState({ requiredLength: 5, startLetter: 'a' });
     const res = useGameStore.getState().submitWord('bread');
     expect(res.accepted).toBe(false);
-    expect(useGameStore.getState().positions[0]).toBe(0);
+    expect(useGameStore.getState().positions[0]).toBe(-1);
   });
 
   it('challenge mode moves back on invalid', () => {
@@ -75,10 +75,10 @@ describe('game store', () => {
     useGameStore.getState().newGame({ boardSize: 10, snakes: [], ladders: [] });
     useGameStore.setState({
       dictionary: dict,
-      requiredLength: 9,
+      requiredLength: 10,
       startLetter: 'a',
     });
-    const res = useGameStore.getState().submitWord('abandoned');
+    const res = useGameStore.getState().submitWord('abandoning');
     expect(res.accepted).toBe(true);
     const state = useGameStore.getState();
     expect(state.positions[0]).toBe(9);
@@ -99,7 +99,7 @@ describe('game store', () => {
       .mockReturnValue('apple');
     useGameStore.getState().endTurn();
     expect(aiSpy).toHaveBeenCalled();
-    expect(useGameStore.getState().positions[1]).toBe(5);
+    expect(useGameStore.getState().positions[1]).toBe(4);
     expect(useGameStore.getState().startLetter).toBe('e');
     expect(useGameStore.getState().current).toBe(0);
     rollSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Begin games with both players off the board, entering on first valid word
- Allow challenge mode penalties to move players back off-board
- Update tests for new starting position and win condition

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ae13166ae08324962cb86bfc7ef43c