### PR TITLE
Improve dice roll timing and UI layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
             />
           ) : (
             <>
-              <div className="flex gap-4 items-start justify-center">
+              <div className="flex gap-2 items-start justify-center">
                 <div
                   className="flex flex-col justify-between"
                   style={{ height: boardHeight }}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,7 +2,7 @@
 import { useGameStore } from '../store/useGameStore';
 import Cell from './Cell';
 import { indexToPosition } from '../engine/board';
-import { LayoutGroup } from 'framer-motion';
+import { LayoutGroup, motion } from 'framer-motion';
 import type { Ref } from 'react';
 
 interface BoardProps {
@@ -197,6 +197,36 @@ export default function Board({ boardRef }: BoardProps) {
         >
           {cells}
         </div>
+        {positions[0] === -1 && (
+          <motion.img
+            layoutId="p1"
+            src="/assets/redpawn.svg"
+            alt="P1"
+            className="absolute"
+            style={{
+              width: `${cellSize * 0.4}%`,
+              height: `${cellSize * 0.4}%`,
+              bottom: `${cellSize * 0.1}%`,
+              left: `-${cellSize * 0.6}%`,
+            }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          />
+        )}
+        {rules.mode !== 'zen' && positions[1] === -1 && (
+          <motion.img
+            layoutId="p2"
+            src="/assets/bluepawn.svg"
+            alt="P2"
+            className="absolute"
+            style={{
+              width: `${cellSize * 0.4}%`,
+              height: `${cellSize * 0.4}%`,
+              bottom: `${cellSize * 0.55}%`,
+              left: `-${cellSize * 0.6}%`,
+            }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          />
+        )}
       </div>
     </LayoutGroup>
   );

--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -8,6 +8,7 @@ export default function Dice() {
   const { lastDie, positions, current, rules } = useGameStore();
   const endTurn = useGameStore((s) => s.endTurn);
   const muted = useGameStore((s) => s.muted);
+  const finishRoll = useGameStore((s) => s.finishRoll);
   const rollSound = useRef<HTMLAudioElement | null>(null);
   const [display, setDisplay] = useState<number>(0);
   const [rolling, setRolling] = useState(false);
@@ -27,6 +28,7 @@ export default function Dice() {
       clearInterval(interval);
       setDisplay(lastDie);
       setRolling(false);
+      finishRoll();
       const remaining = rules.boardSize - 1 - positions[current];
       if (lastDie - 1 > remaining) {
         alert('Need exact roll to finish. Turn skipped.');

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -11,6 +11,7 @@ export default function HUD() {
     current,
     rules,
     remainingTime,
+    rolling,
   } = useGameStore();
   const decrementTimer = useGameStore((s) => s.decrementTimer);
   const endTurn = useGameStore((s) => s.endTurn);
@@ -32,8 +33,8 @@ export default function HUD() {
     <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
       <Dice />
       {/* Display current turn information */}
-      <div>Required: {requiredLength || '-'}</div>
-      <div>Start: {startLetter}</div>
+      <div>Required: {rolling ? '-' : requiredLength || '-'}</div>
+      <div>Start: {rolling ? '-' : startLetter}</div>
       <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>
       <div>Wildcards: {wildcards[current]}</div>
       {rules.timer && <div>Time: {remainingTime || '-'}</div>}

--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -26,17 +26,21 @@ export default function WordInput() {
     rules,
     wildcards,
     current,
+    rolling,
   } = useGameStore();
 
   // Check if current input is valid according to game rules
-  const validation = validateWord(word, {
-    length: requiredLength,
-    startLetter,
-    usedWords,
-    hasWord: (w) => hasWord(dictionary, w),
-    noRepeats: rules.noRepeats,
-    useWildcard,
-  });
+  const validation =
+    requiredLength > 0
+      ? validateWord(word, {
+          length: requiredLength,
+          startLetter,
+          usedWords,
+          hasWord: (w) => hasWord(dictionary, w),
+          noRepeats: rules.noRepeats,
+          useWildcard,
+        })
+      : { accepted: false as const };
 
   useEffect(() => {
     setHints([]);
@@ -70,63 +74,69 @@ export default function WordInput() {
 
   return (
     <div className="p-4 bg-white rounded shadow space-y-2">
-      <div className="flex space-x-2 items-center">
-        <label htmlFor="word-input" className="sr-only">
-          Enter word
-        </label>
-        <input
-          id="word-input"
-          type="text"
-          className="border p-1 rounded"
-          value={word}
-          onChange={(e) => setWord(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              handleSubmit();
-            }
-          }}
-        />
-        {/* Optionally bypass starting letter rule */}
-        <label htmlFor="use-wildcard" className="flex items-center space-x-1">
+      <div className="flex items-start space-x-2">
+        <div className="flex-1">
+          <label htmlFor="word-input" className="sr-only">
+            Enter word
+          </label>
           <input
-            id="use-wildcard"
-            type="checkbox"
-            checked={useWildcard}
-            disabled={!canUseWildcard}
-            onChange={() => setUseWildcard(!useWildcard)}
+            id="word-input"
+            type="text"
+            className="border p-1 rounded w-full"
+            value={word}
+            onChange={(e) => setWord(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
           />
-          <span>Wildcard</span>
-        </label>
-        <button
-          className="border px-2 bg-primary text-white rounded disabled:opacity-50"
-          onClick={handleSubmit}
-          disabled={!validation.accepted}
-          aria-label="Submit word"
-        >
-          Submit
-        </button>
-        <button
-          type="button"
-          className="border px-2 rounded"
-          onClick={() => {
-            setWord('');
-            setUseWildcard(false);
-            endTurn();
-          }}
-        >
-          Concede
-        </button>
-        <button
-          type="button"
-          className="border px-2 rounded"
-          onClick={handleHint}
-          aria-label="Show hints"
-        >
-          Hint
-        </button>
+        </div>
+        <div className="flex flex-col space-y-2">
+          {/* Optionally bypass starting letter rule */}
+          <label htmlFor="use-wildcard" className="flex items-center space-x-1">
+            <input
+              id="use-wildcard"
+              type="checkbox"
+              checked={useWildcard}
+              disabled={!canUseWildcard || rolling}
+              onChange={() => setUseWildcard(!useWildcard)}
+            />
+            <span>Wildcard</span>
+          </label>
+          <button
+            className="border px-2 bg-primary text-white rounded disabled:opacity-50"
+            onClick={handleSubmit}
+            disabled={!validation.accepted || rolling}
+            aria-label="Submit word"
+          >
+            Submit
+          </button>
+          <button
+            type="button"
+            className="border px-2 rounded disabled:opacity-50"
+            onClick={() => {
+              setWord('');
+              setUseWildcard(false);
+              endTurn();
+            }}
+            disabled={rolling}
+          >
+            Concede
+          </button>
+          <button
+            type="button"
+            className="border px-2 rounded disabled:opacity-50"
+            onClick={handleHint}
+            aria-label="Show hints"
+            disabled={rolling}
+          >
+            Hint
+          </button>
+        </div>
       </div>
-      {!validation.accepted && (word.length > 0 || requiredLength > 0) && (
+      {!validation.accepted && requiredLength > 0 && word.length > 0 && (
         <div className="text-sm text-red-500">
           {messages[validation.reason ?? ''] || ''}
         </div>

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -17,12 +17,17 @@ beforeEach(() => {
 });
 
 describe('game store', () => {
-  it('roll sets required length', () => {
+  it('roll sets required length after finish', () => {
     useGameStore.getState().roll();
-    const { lastDie, requiredLength } = useGameStore.getState();
-    expect(lastDie).toBeGreaterThanOrEqual(3);
-    expect(lastDie).toBeLessThanOrEqual(6);
-    expect(requiredLength).toBe(lastDie);
+    let state = useGameStore.getState();
+    expect(state.rolling).toBe(true);
+    expect(state.requiredLength).toBe(0);
+    useGameStore.getState().finishRoll();
+    state = useGameStore.getState();
+    expect(state.lastDie).toBeGreaterThanOrEqual(3);
+    expect(state.lastDie).toBeLessThanOrEqual(6);
+    expect(state.requiredLength).toBe(state.lastDie);
+    expect(state.rolling).toBe(false);
   });
 
   it('submit valid word moves player and updates start letter', () => {


### PR DESCRIPTION
## Summary
- Show starting pawns beside the board
- Delay die and word prompts until roll animation ends
- Stack word entry controls vertically and tighten layout

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aed4ef0a4083249dd77f316d0e3b0d