### PR TITLE
Improve dice roll timing and board visuals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
             />
           ) : (
             <>
-              <div className="flex gap-4 items-start justify-center">
+              <div className="flex gap-2 items-start justify-center">
                 <div
                   className="flex flex-col justify-between"
                   style={{ height: boardHeight }}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,8 +2,8 @@
 import { useGameStore } from '../store/useGameStore';
 import Cell from './Cell';
 import { indexToPosition } from '../engine/board';
-import { LayoutGroup } from 'framer-motion';
-import type { Ref } from 'react';
+import { LayoutGroup, motion } from 'framer-motion';
+import { useMemo, type Ref } from 'react';
 
 interface BoardProps {
   boardRef?: Ref<HTMLDivElement>;
@@ -32,27 +32,28 @@ export default function Board({ boardRef }: BoardProps) {
     }
   }
 
-  // Decorative snakes and ladders
-  const decorations = [
-    ...rules.snakes.map((s) => ({ ...s, type: 'snake' as const })),
-    ...rules.ladders.map((l) => ({ ...l, type: 'ladder' as const })),
-  ].flatMap((item, i) => {
-    const from = indexToPosition(item.from, rules.boardSize);
-    const to = indexToPosition(item.to, rules.boardSize);
-    const dx = (to.col - from.col) * cellSize;
-    const dy = (from.row - to.row) * cellSize;
-    const length = Math.sqrt(dx * dx + dy * dy);
-    const x = from.col * cellSize + cellSize / 2;
-    const y = (width - 1 - from.row) * cellSize + cellSize / 2;
+  const decorations = useMemo(() => {
+    const elems: JSX.Element[] = [];
+    const randHue = () => Math.floor(Math.random() * 360);
 
-    if (item.type === 'snake') {
+    rules.snakes.forEach((s, i) => {
+      const from = indexToPosition(s.from, rules.boardSize);
+      const to = indexToPosition(s.to, rules.boardSize);
+      const dx = (to.col - from.col) * cellSize;
+      const dy = (from.row - to.row) * cellSize;
+      const x = from.col * cellSize + cellSize / 2;
+      const y = (width - 1 - from.row) * cellSize + cellSize / 2;
+
       const startX = x;
       const startY = y;
       const endX = x + dx;
       const endY = y + dy;
       const strokeWidth = cellSize * 0.15;
+      const hue = randHue();
+      const light = `hsl(${hue} 70% 70%)`;
+      const dark = `hsl(${hue} 70% 40%)`;
 
-      return (
+      elems.push(
         <svg
           key={`snake-${i}`}
           className="absolute inset-0 pointer-events-none"
@@ -68,8 +69,8 @@ export default function Board({ boardRef }: BoardProps) {
               x2={endX}
               y2={endY}
             >
-              <stop offset="0%" stopColor="#4ade80" stopOpacity="0.6" />
-              <stop offset="100%" stopColor="#15803d" stopOpacity="0.6" />
+              <stop offset="0%" stopColor={light} stopOpacity="0.6" />
+              <stop offset="100%" stopColor={dark} stopOpacity="0.6" />
             </linearGradient>
             <marker
               id={`snake-head-${i}`}
@@ -79,7 +80,7 @@ export default function Board({ boardRef }: BoardProps) {
               refY="2"
               orient="auto"
             >
-              <polygon points="0,0 4,2 0,4" fill="#15803d" fillOpacity="0.8" />
+              <polygon points="0,0 4,2 0,4" fill={dark} fillOpacity="0.8" />
             </marker>
             <marker
               id={`snake-tail-${i}`}
@@ -89,7 +90,7 @@ export default function Board({ boardRef }: BoardProps) {
               refY="2"
               orient="auto"
             >
-              <circle cx="2" cy="2" r="1.5" fill="#4ade80" fillOpacity="0.8" />
+              <circle cx="2" cy="2" r="1.5" fill={light} fillOpacity="0.8" />
             </marker>
           </defs>
           <line
@@ -103,84 +104,98 @@ export default function Board({ boardRef }: BoardProps) {
             markerStart={`url(#snake-tail-${i})`}
             markerEnd={`url(#snake-head-${i})`}
           />
-        </svg>
+        </svg>,
       );
-    }
+    });
 
-    // Ladder with separate rails and rungs drawn as SVG lines
-    const railSpacing = cellSize * 0.5;
-    const railWidth = cellSize * 0.1;
-    const stepCount = Math.max(2, Math.floor(length / cellSize));
-    const angleRad = Math.atan2(dy, dx);
-    const ux = Math.cos(angleRad);
-    const uy = Math.sin(angleRad);
-    const px = -uy;
-    const py = ux;
+    rules.ladders.forEach((l, i) => {
+      const from = indexToPosition(l.from, rules.boardSize);
+      const to = indexToPosition(l.to, rules.boardSize);
+      const dx = (to.col - from.col) * cellSize;
+      const dy = (from.row - to.row) * cellSize;
+      const length = Math.sqrt(dx * dx + dy * dy);
+      const x = from.col * cellSize + cellSize / 2;
+      const y = (width - 1 - from.row) * cellSize + cellSize / 2;
 
-    const startX = x;
-    const startY = y;
-    const endX = x + ux * length;
-    const endY = y + uy * length;
+      const railSpacing = cellSize * 0.5;
+      const railWidth = cellSize * 0.1;
+      const stepCount = Math.max(2, Math.floor(length / cellSize));
+      const angleRad = Math.atan2(dy, dx);
+      const ux = Math.cos(angleRad);
+      const uy = Math.sin(angleRad);
+      const px = -uy;
+      const py = ux;
 
-    const r1sx = startX + px * (railSpacing / 2);
-    const r1sy = startY + py * (railSpacing / 2);
-    const r1ex = endX + px * (railSpacing / 2);
-    const r1ey = endY + py * (railSpacing / 2);
+      const startX = x;
+      const startY = y;
+      const endX = x + ux * length;
+      const endY = y + uy * length;
 
-    const r2sx = startX - px * (railSpacing / 2);
-    const r2sy = startY - py * (railSpacing / 2);
-    const r2ex = endX - px * (railSpacing / 2);
-    const r2ey = endY - py * (railSpacing / 2);
+      const r1sx = startX + px * (railSpacing / 2);
+      const r1sy = startY + py * (railSpacing / 2);
+      const r1ex = endX + px * (railSpacing / 2);
+      const r1ey = endY + py * (railSpacing / 2);
 
-    return (
-      <svg
-        key={`ladder-${i}`}
-        className="absolute inset-0 pointer-events-none"
-        viewBox="0 0 100 100"
-        preserveAspectRatio="none"
-      >
-        <line
-          x1={r1sx}
-          y1={r1sy}
-          x2={r1ex}
-          y2={r1ey}
-          stroke="#eab308"
-          strokeWidth={railWidth}
-          strokeLinecap="round"
-        />
-        <line
-          x1={r2sx}
-          y1={r2sy}
-          x2={r2ex}
-          y2={r2ey}
-          stroke="#eab308"
-          strokeWidth={railWidth}
-          strokeLinecap="round"
-        />
-        {Array.from({ length: stepCount }).map((_, j) => {
-          const t = (j + 1) / (stepCount + 1);
-          const cx = startX + ux * length * t;
-          const cy = startY + uy * length * t;
-          const rsx = cx + px * (railSpacing / 2);
-          const rsy = cy + py * (railSpacing / 2);
-          const rex = cx - px * (railSpacing / 2);
-          const rey = cy - py * (railSpacing / 2);
-          return (
-            <line
-              key={j}
-              x1={rsx}
-              y1={rsy}
-              x2={rex}
-              y2={rey}
-              stroke="#eab308"
-              strokeWidth={railWidth}
-              strokeLinecap="round"
-            />
-          );
-        })}
-      </svg>
-    );
-  });
+      const r2sx = startX - px * (railSpacing / 2);
+      const r2sy = startY - py * (railSpacing / 2);
+      const r2ex = endX - px * (railSpacing / 2);
+      const r2ey = endY - py * (railSpacing / 2);
+
+      const hue = randHue();
+      const color = `hsl(${hue} 70% 50%)`;
+
+      elems.push(
+        <svg
+          key={`ladder-${i}`}
+          className="absolute inset-0 pointer-events-none"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+        >
+          <line
+            x1={r1sx}
+            y1={r1sy}
+            x2={r1ex}
+            y2={r1ey}
+            stroke={color}
+            strokeWidth={railWidth}
+            strokeLinecap="round"
+          />
+          <line
+            x1={r2sx}
+            y1={r2sy}
+            x2={r2ex}
+            y2={r2ey}
+            stroke={color}
+            strokeWidth={railWidth}
+            strokeLinecap="round"
+          />
+          {Array.from({ length: stepCount }).map((_, j) => {
+            const t = (j + 1) / (stepCount + 1);
+            const cx = startX + ux * length * t;
+            const cy = startY + uy * length * t;
+            const rsx = cx + px * (railSpacing / 2);
+            const rsy = cy + py * (railSpacing / 2);
+            const rex = cx - px * (railSpacing / 2);
+            const rey = cy - py * (railSpacing / 2);
+            return (
+              <line
+                key={j}
+                x1={rsx}
+                y1={rsy}
+                x2={rex}
+                y2={rey}
+                stroke={color}
+                strokeWidth={railWidth}
+                strokeLinecap="round"
+              />
+            );
+          })}
+        </svg>,
+      );
+    });
+
+    return elems;
+  }, [rules.snakes, rules.ladders, cellSize, width, rules.boardSize]);
 
   return (
     <LayoutGroup>
@@ -197,6 +212,36 @@ export default function Board({ boardRef }: BoardProps) {
         >
           {cells}
         </div>
+        {positions[0] === -1 && (
+          <motion.img
+            layoutId="p1"
+            src="/assets/redpawn.svg"
+            alt="P1"
+            className="absolute z-20"
+            style={{
+              width: `${cellSize * 0.4}%`,
+              height: `${cellSize * 0.4}%`,
+              bottom: `${cellSize * 0.1}%`,
+              left: `${cellSize * 0.1}%`,
+            }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          />
+        )}
+        {rules.mode !== 'zen' && positions[1] === -1 && (
+          <motion.img
+            layoutId="p2"
+            src="/assets/bluepawn.svg"
+            alt="P2"
+            className="absolute z-20"
+            style={{
+              width: `${cellSize * 0.4}%`,
+              height: `${cellSize * 0.4}%`,
+              bottom: `${cellSize * 0.55}%`,
+              left: `${cellSize * 0.1}%`,
+            }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          />
+        )}
       </div>
     </LayoutGroup>
   );

--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -8,6 +8,7 @@ export default function Dice() {
   const { lastDie, positions, current, rules } = useGameStore();
   const endTurn = useGameStore((s) => s.endTurn);
   const muted = useGameStore((s) => s.muted);
+  const finishRoll = useGameStore((s) => s.finishRoll);
   const rollSound = useRef<HTMLAudioElement | null>(null);
   const [display, setDisplay] = useState<number>(0);
   const [rolling, setRolling] = useState(false);
@@ -20,6 +21,7 @@ export default function Dice() {
     if (lastDie === 0) return;
     if (!muted) rollSound.current?.play();
     setRolling(true);
+    setDisplay(0);
     const interval = setInterval(() => {
       setDisplay(Math.floor(Math.random() * 6) + 1);
     }, 100);
@@ -27,6 +29,7 @@ export default function Dice() {
       clearInterval(interval);
       setDisplay(lastDie);
       setRolling(false);
+      finishRoll();
       const remaining = rules.boardSize - 1 - positions[current];
       if (lastDie - 1 > remaining) {
         alert('Need exact roll to finish. Turn skipped.');
@@ -37,7 +40,7 @@ export default function Dice() {
       clearInterval(interval);
       clearTimeout(timeout);
     };
-  }, [lastDie, positions, current, rules.boardSize, endTurn, muted]);
+  }, [lastDie, positions, current, rules.boardSize, endTurn, muted, finishRoll]);
 
   const face = display ? faces[display - 1] : '';
   return (

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -11,6 +11,7 @@ export default function HUD() {
     current,
     rules,
     remainingTime,
+    rolling,
   } = useGameStore();
   const decrementTimer = useGameStore((s) => s.decrementTimer);
   const endTurn = useGameStore((s) => s.endTurn);
@@ -32,8 +33,8 @@ export default function HUD() {
     <div className="p-4 bg-white rounded shadow flex flex-col space-y-2 text-primary">
       <Dice />
       {/* Display current turn information */}
-      <div>Required: {requiredLength || '-'}</div>
-      <div>Start: {startLetter}</div>
+      <div>Required: {rolling ? '-' : requiredLength || '-'}</div>
+      <div>Start: {rolling ? '-' : startLetter}</div>
       <div>Current: {rules.mode === 'zen' ? 'P1' : `P${current + 1}`}</div>
       <div>Wildcards: {wildcards[current]}</div>
       {rules.timer && <div>Time: {remainingTime || '-'}</div>}

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -17,12 +17,17 @@ beforeEach(() => {
 });
 
 describe('game store', () => {
-  it('roll sets required length', () => {
+  it('roll sets required length after finish', () => {
     useGameStore.getState().roll();
-    const { lastDie, requiredLength } = useGameStore.getState();
-    expect(lastDie).toBeGreaterThanOrEqual(3);
-    expect(lastDie).toBeLessThanOrEqual(6);
-    expect(requiredLength).toBe(lastDie);
+    let state = useGameStore.getState();
+    expect(state.rolling).toBe(true);
+    expect(state.requiredLength).toBe(0);
+    useGameStore.getState().finishRoll();
+    state = useGameStore.getState();
+    expect(state.lastDie).toBeGreaterThanOrEqual(3);
+    expect(state.lastDie).toBeLessThanOrEqual(6);
+    expect(state.requiredLength).toBe(state.lastDie);
+    expect(state.rolling).toBe(false);
   });
 
   it('submit valid word moves player and updates start letter', () => {


### PR DESCRIPTION
## Summary
- Show starting pawns on the board before the first move
- Delay die result until animation finishes and tidy roll display
- Stack word input controls vertically for easier access
- Randomize snake and ladder colors for better contrast

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aed4ef0a4083249dd77f316d0e3b0d