### PR TITLE
Ensure word chains share last square and simplify input layout

### DIFF
--- a/src/components/WordInput.tsx
+++ b/src/components/WordInput.tsx
@@ -92,81 +92,83 @@ export default function WordInput() {
     <div className="p-4 bg-white rounded shadow space-y-2">
       {/* Use a form to centralize submit + Enter key handling */}
       <form
-        className="flex items-start space-x-2"
+        className="flex flex-col space-y-2"
         onSubmit={(e) => {
           e.preventDefault();
           handleSubmit();
         }}
       >
-        <div className="flex-1">
-          <label htmlFor="word-input" className="sr-only">
-            Enter word
-          </label>
+        <label htmlFor="word-input" className="sr-only">
+          Enter word
+        </label>
+        <input
+          id="word-input"
+          type="text"
+          className="border p-1 rounded w-full"
+          value={word}
+          onChange={(e) => setWord(e.target.value)}
+          disabled={rolling}
+          aria-invalid={
+            !validation.accepted && requiredLength > 0 && word.length > 0
+          }
+          aria-describedby={!validation.accepted ? 'word-error' : undefined}
+        />
+
+        {/* Optionally bypass starting-letter rule */}
+        <label htmlFor="use-wildcard" className="flex items-center space-x-1">
           <input
-            id="word-input"
-            type="text"
-            className="border p-1 rounded w-full"
-            value={word}
-            onChange={(e) => setWord(e.target.value)}
-            disabled={rolling}
-            aria-invalid={!validation.accepted && requiredLength > 0 && word.length > 0}
-            aria-describedby={!validation.accepted ? 'word-error' : undefined}
+            id="use-wildcard"
+            type="checkbox"
+            checked={useWildcard}
+            disabled={!canUseWildcard || rolling}
+            onChange={() => setUseWildcard(!useWildcard)}
           />
-        </div>
+          <span>Wildcard</span>
+        </label>
 
-        <div className="flex flex-col space-y-2">
-          {/* Optionally bypass starting-letter rule */}
-          <label htmlFor="use-wildcard" className="flex items-center space-x-1">
-            <input
-              id="use-wildcard"
-              type="checkbox"
-              checked={useWildcard}
-              disabled={!canUseWildcard || rolling}
-              onChange={() => setUseWildcard(!useWildcard)}
-            />
-            <span>Wildcard</span>
-          </label>
+        <button
+          type="submit"
+          className="border px-2 bg-primary text-white rounded disabled:opacity-50"
+          disabled={!validation.accepted || rolling}
+          aria-label="Submit word"
+        >
+          Submit
+        </button>
 
-          <button
-            type="submit"
-            className="border px-2 bg-primary text-white rounded disabled:opacity-50"
-            disabled={!validation.accepted || rolling}
-            aria-label="Submit word"
-          >
-            Submit
-          </button>
+        <button
+          type="button"
+          className="border px-2 rounded disabled:opacity-50"
+          onClick={() => {
+            if (rolling) return;
+            setWord('');
+            setUseWildcard(false);
+            endTurn();
+            setHints([]);
+          }}
+          disabled={rolling}
+        >
+          Concede
+        </button>
 
-          <button
-            type="button"
-            className="border px-2 rounded disabled:opacity-50"
-            onClick={() => {
-              if (rolling) return;
-              setWord('');
-              setUseWildcard(false);
-              endTurn();
-              setHints([]);
-            }}
-            disabled={rolling}
-          >
-            Concede
-          </button>
-
-          <button
-            type="button"
-            className="border px-2 rounded disabled:opacity-50"
-            onClick={handleHint}
-            aria-label="Show hints"
-            disabled={rolling || requiredLength <= 0}
-          >
-            Hint
-          </button>
-        </div>
+        <button
+          type="button"
+          className="border px-2 rounded disabled:opacity-50"
+          onClick={handleHint}
+          aria-label="Show hints"
+          disabled={rolling || requiredLength <= 0}
+        >
+          Hint
+        </button>
       </form>
 
       {/* Inline validation feedback */}
       {!validation.accepted && requiredLength > 0 && word.length > 0 && (
-        <div id="word-error" className="text-sm text-red-500" aria-live="polite">
-          {reasonKey ? messages[reasonKey] ?? '' : ''}
+        <div
+          id="word-error"
+          className="text-sm text-red-500"
+          aria-live="polite"
+        >
+          {reasonKey ? (messages[reasonKey] ?? '') : ''}
         </div>
       )}
 

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -134,10 +134,15 @@ export const useGameStore = create<GameState>((set, get) => ({
       }
       return validation;
     }
-    // Move forward by the full length of the accepted word. Players start
-    // off-board at index -1, so a five-letter word lands on cell 4
-    // (the board itself remains zero-indexed).
-    const move = normalized.length;
+    // Move forward placing the first letter on the current cell so the last
+    // letter of one word is the starting square for the next. Players start
+    // off-board at index -1, in which case the entire word determines the
+    // movement. Once on the board, only the trailing letters beyond the first
+    // advance the position.
+    const move =
+      state.positions[state.current] === -1
+        ? normalized.length
+        : normalized.length - 1;
     const remaining =
       state.rules.boardSize - 1 - state.positions[state.current];
     if (move > remaining) {
@@ -152,11 +157,12 @@ export const useGameStore = create<GameState>((set, get) => ({
     const newWildcards = { ...state.wildcards };
     if (useWildcard) newWildcards[state.current]--;
     const letters = [...state.boardLetters];
-    // Place the letters along the path the player travelled, starting with
-    // the cell immediately after the starting position so the final letter
-    // lands on the destination cell.
+    // Place letters starting on the current cell so the first letter overlaps
+    // the previous word's last letter and the final letter lands on the
+    // destination cell.
+    const startIdx = Math.max(state.positions[state.current], 0);
     for (let i = 0; i < normalized.length; i++) {
-      const idx = state.positions[state.current] + i + 1;
+      const idx = startIdx + i;
       if (idx < letters.length) letters[idx] = normalized[i];
     }
     const win = position === state.rules.boardSize - 1;

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -38,6 +38,26 @@ describe('game store', () => {
     expect(useGameStore.getState().startLetter).toBe('e');
   });
 
+  it('next word starts on last letter of previous word', () => {
+    useGameStore.setState({ requiredLength: 5 });
+    useGameStore.getState().submitWord('apple');
+    useGameStore.setState({ requiredLength: 4 });
+    const res = useGameStore.getState().submitWord('evil');
+    expect(res.accepted).toBe(true);
+    const state = useGameStore.getState();
+    expect(state.positions[0]).toBe(14); // ladder from 7 to 14
+    expect(state.boardLetters.slice(0, 8)).toEqual([
+      'a',
+      'p',
+      'p',
+      'l',
+      'e',
+      'v',
+      'i',
+      'l',
+    ]);
+  });
+
   it('wildcard bypasses start letter and decrements', () => {
     useGameStore.setState({ requiredLength: 5, startLetter: 'b' });
     const res = useGameStore.getState().submitWord('apple', true);


### PR DESCRIPTION
## Summary
- Stack word input controls in a single column for cleaner UI
- Move logic places the next word's first letter on the previous word's final square, sharing the cell
- Add regression test to confirm overlapping word behavior

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeeffbe42083248d1ffd4dc39288b6